### PR TITLE
feat: carta holografica de verdade, e o tilt 3D que nunca aplicou

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -758,7 +758,17 @@ select {
   transform-style: preserve-3d;
   transform: rotateX(var(--tilt-x, 0deg)) rotateY(var(--tilt-y, 0deg));
   transition: transform 340ms cubic-bezier(0.22, 1, 0.36, 1);
-  animation: reveal 720ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  /*
+   * `backwards` e nao `both`.
+   *
+   * Com `both`, o quadro 100% desta animacao (`transform: none`) continua valendo
+   * depois que ela termina, e animacao vence declaracao normal na cascata — o
+   * `transform` acima nunca chegava a ser aplicado. A carta ficava permanentemente
+   * chapada por mais que o JS escrevesse `--tilt-x`. `backwards` cobre so o que o
+   * `both` existia para cobrir (o estado inicial antes do primeiro quadro) e
+   * devolve o controle do transform assim que a revelacao acaba.
+   */
+  animation: reveal 720ms cubic-bezier(0.22, 1, 0.36, 1) backwards;
   will-change: transform;
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -755,9 +755,19 @@ select {
 .tilt-card {
   position: relative;
   border-radius: 16px;
-  transform-style: preserve-3d;
-  transform: rotateX(var(--tilt-x, 0deg)) rotateY(var(--tilt-y, 0deg));
-  transition: transform 340ms cubic-bezier(0.22, 1, 0.36, 1);
+
+  /*
+   * `--active` vai de 0 a 1 no laço de rAF do TiltCard e é o dimmer de toda a
+   * pilha: inclinação, elevação, brilho e espectro leem daqui. Uma variável só
+   * garante que tudo acenda e apague junto, sem transição de CSS competindo com
+   * a interpolação do JS.
+   */
+  --active: 0;
+  --foil: 0;
+
+  transform: translateZ(calc(var(--active) * 26px)) rotateX(var(--tilt-x, 0deg))
+    rotateY(var(--tilt-y, 0deg));
+
   /*
    * `backwards` e nao `both`.
    *
@@ -772,15 +782,18 @@ select {
   will-change: transform;
 }
 
-.tilt-card[data-active] {
-  transition: transform 80ms linear;
-}
-
 .tilt-card img {
   width: 100%;
   height: auto;
   border-radius: 16px;
-  filter: drop-shadow(0 18px 34px rgb(0 0 0 / 0.45));
+  /*
+   * A sombra cresce com a elevação: carta levantada projeta sombra maior e mais
+   * difusa. Sem isso o `translateZ` lê como zoom, não como altura.
+   */
+  filter: drop-shadow(
+    0 calc(18px + var(--active) * 16px) calc(34px + var(--active) * 26px)
+      rgb(0 0 0 / calc(0.45 + var(--active) * 0.2))
+  );
 }
 
 .tilt-glare {
@@ -788,45 +801,183 @@ select {
   inset: 0;
   border-radius: 16px;
   pointer-events: none;
-  opacity: 0;
-  transition: opacity 240ms ease;
+  opacity: var(--active);
+  /*
+   * Bem mais discreto do que era quando esta camada estava sozinha. Com a pilha
+   * holo por cima, um borrão branco largo só soma névoa: as três camadas de foil
+   * já clareiam a região do ponteiro, e o brilho da fonte de luz vira um ponto
+   * quente pequeno em vez do reflexo inteiro.
+   */
   background: radial-gradient(
     circle at var(--glare-x, 50%) var(--glare-y, 50%),
-    rgb(255 255 255 / 0.34),
-    transparent 46%
+    rgb(255 255 255 / 0.2),
+    transparent 38%
   );
 }
 
-.tilt-card[data-active] .tilt-glare {
-  opacity: 1;
-}
-
 /*
- * Foil especular. Camada por cima do PNG, nunca dentro dele — a imagem exportada
- * já carrega o seu próprio foil, gerado na build (RFC 7.1, 9.6).
+ * ---------------------------------------------------------------- foil holo
  *
- * `screen` faz o preto do filtro desaparecer e só o brilho somar. Fica fraco
- * parado e acende no hover, porque a luz só existe quando há ponteiro para
- * movê-la.
+ * Camadas por cima do PNG, nunca dentro dele — a imagem exportada já carrega o
+ * seu próprio foil, gerado na build (RFC 7.1, 9.6).
+ *
+ * Todas herdam a mesma conta de opacidade: `--foil` (a raridade, fixa) × uma
+ * base em repouso + o que o ponteiro acrescenta. A carta nunca fica morta
+ * parada, mas só chega ao brilho cheio quando alguém a toca.
  */
-.tilt-foil {
+.tilt-holo {
   position: absolute;
   inset: 0;
   border-radius: 16px;
   overflow: hidden;
   pointer-events: none;
-  mix-blend-mode: screen;
-  opacity: 0.28;
-  transition: opacity 240ms ease;
 }
 
-.tilt-card[data-active] .tilt-foil {
-  opacity: 0.75;
+.tilt-holo > * {
+  position: absolute;
+  inset: 0;
+}
+
+/*
+ * Relevo especular: o grão de metal que reflete a luz do ponteiro.
+ *
+ * Mascarado em volta do ponteiro, e não espalhado pela carta inteira. Sem a
+ * máscara o relevo cobre os 500×700 num véu leitoso uniforme e o avatar
+ * desaparece atrás dele — o que é fisicamente errado, além de feio: relevo só
+ * acende onde a luz bate. A máscara é bem mais larga que a do espectro porque o
+ * reflexo difuso do metal se espalha mais que a refração.
+ */
+.tilt-foil {
+  mix-blend-mode: screen;
+  opacity: calc(var(--foil) * (0.07 + var(--active) * 0.25));
+  -webkit-mask-image: radial-gradient(
+    circle at var(--glare-x, 50%) var(--glare-y, 50%),
+    #000 0%,
+    rgb(0 0 0 / 0.45) 38%,
+    transparent 74%
+  );
+  mask-image: radial-gradient(
+    circle at var(--glare-x, 50%) var(--glare-y, 50%),
+    #000 0%,
+    rgb(0 0 0 / 0.45) 38%,
+    transparent 74%
+  );
 }
 
 .tilt-foil-svg {
   width: 100%;
   height: 100%;
+}
+
+/*
+ * Faixas de espectro — a camada que faz a carta ler como holográfica em vez de
+ * apenas brilhante.
+ *
+ * `mix-blend-mode: color`, e não `color-dodge` nem `hard-light`. Os dois foram
+ * tentados e falham pelo mesmo motivo: a arte destas cartas é clara (moldura
+ * pastel, avatar sobre fundo claro), então qualquer modo que some luz satura
+ * para branco e enevoa o nome, os stats e o rosto — foi exatamente o que a
+ * primeira versão desta camada fazia.
+ *
+ * `color` troca **só** matiz e saturação e mantém a luminosidade do que está
+ * embaixo. O texto preto continua preto, o contraste da arte não se move, e
+ * ainda assim a carta ganha as faixas de arco-íris de verdade. O brilho que o
+ * holo também precisa vem de outra camada (`.tilt-foil`), que é onde ele deve
+ * estar: cor e luz separadas, cada uma controlável sem estragar a outra.
+ *
+ * A máscara radial prende o espectro a um halo em volta do ponteiro. Espectro
+ * cobrindo a carta inteira lê como filtro de foto; concentrado num ponto que se
+ * move, lê como reflexo.
+ */
+.tilt-spectral {
+  mix-blend-mode: color;
+  opacity: calc(var(--foil) * var(--active) * 0.85);
+  background: repeating-linear-gradient(
+    112deg,
+    hsl(348 92% 58%) 0%,
+    hsl(45 96% 58%) 5%,
+    hsl(140 82% 54%) 10%,
+    hsl(192 94% 56%) 15%,
+    hsl(268 90% 62%) 20%,
+    hsl(320 92% 60%) 25%,
+    hsl(348 92% 58%) 30%
+  );
+  background-size: 220% 220%;
+  background-position: var(--holo-shift, 50%) var(--holo-drift, 50%);
+  -webkit-mask-image: radial-gradient(
+    circle at var(--glare-x, 50%) var(--glare-y, 50%),
+    #000 0%,
+    rgb(0 0 0 / 0.45) 28%,
+    transparent 58%
+  );
+  mask-image: radial-gradient(
+    circle at var(--glare-x, 50%) var(--glare-y, 50%),
+    #000 0%,
+    rgb(0 0 0 / 0.45) 28%,
+    transparent 58%
+  );
+}
+
+/* Lâmina diagonal: o reflexo duro da fonte de luz varrendo a superfície. */
+.tilt-sheen {
+  mix-blend-mode: overlay;
+  opacity: calc(var(--foil) * (0.08 + var(--active) * 0.24));
+  background: linear-gradient(
+    108deg,
+    transparent 36%,
+    rgb(255 255 255 / 0.72) 47%,
+    rgb(255 255 255 / 0.22) 53%,
+    transparent 64%
+  );
+  background-size: 260% 100%;
+  background-position: var(--sheen-shift, 50%) center;
+}
+
+/*
+ * Granulado fixo. Não se move e não reage — existe só para quebrar a lisura dos
+ * gradientes acima, que sem ele denunciam CSS à primeira vista. Data URI porque
+ * um request de rede para 400 bytes de ruído não se justifica.
+ */
+.tilt-grain {
+  mix-blend-mode: overlay;
+  opacity: calc(var(--foil) * 0.16);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='120' height='120'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='3' stitchTiles='stitch'/><feColorMatrix type='saturate' values='0'/></filter><rect width='120' height='120' filter='url(%23n)' opacity='0.55'/></svg>");
+}
+
+/*
+ * Metal do tier tinge o espectro. `ultra_rare` é prata e
+ * `special_illustration_rare`/`hyper_rare` são ouro na moldura impressa
+ * (`cardTreatment`); sem isto o reflexo ao vivo sai igual nos três e desmente a
+ * moldura que está logo embaixo.
+ */
+.tilt-holo[data-metal="gold"] .tilt-spectral {
+  filter: hue-rotate(-18deg) saturate(1.15);
+}
+
+.tilt-holo[data-metal="silver"] .tilt-spectral {
+  filter: saturate(0.55) brightness(1.12);
+}
+
+/* Fio de luz na borda, como o corte metálico de uma carta de verdade. */
+.tilt-card[data-foil]::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 16px;
+  pointer-events: none;
+  padding: 1px;
+  opacity: calc(var(--foil) * (0.25 + var(--active) * 0.6));
+  background: linear-gradient(
+    calc(120deg + var(--tilt-y, 0deg)),
+    rgb(255 255 255 / 0.9),
+    rgb(255 255 255 / 0.1) 45%,
+    rgb(255 255 255 / 0.75)
+  );
+  /* Máscara xor: pinta só a moldura de 1px, e não o miolo. */
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  mask-composite: exclude;
 }
 
 /*
@@ -846,6 +997,23 @@ select {
     opacity: 1;
     transform: none;
     filter: none;
+  }
+}
+
+/*
+ * Sem movimento, o foil vira brilho estático em vez de sumir (docs/foil-especular.md).
+ * A regra global já zera durações; o que falta é impedir que a carta fique
+ * apagada esperando um ponteiro cujo efeito foi desligado.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .tilt-card {
+    --active: 0.5;
+    transform: none;
+  }
+
+  .tilt-spectral,
+  .tilt-glare {
+    opacity: 0;
   }
 }
 
@@ -871,11 +1039,45 @@ select {
   margin-inline: calc(50% - min(680px, 50vw - 20px));
 }
 
+/*
+ * Auréola do elemento atrás da carta.
+ *
+ * A cor do tipo já existe em `--element` (o `CardPanel` a define no painel
+ * inteiro), mas até aqui ela só aparecia em texto de 13px — a página ficava
+ * idêntica para uma carta de Fogo e uma de Água, com o fundo cinza-azulado do
+ * produto valendo para as dezoito. A auréola dá o ambiente sem tocar na carta:
+ * é luz **atrás** dela, não em cima, e por isso não briga com o PNG exportado
+ * nem com o foil.
+ *
+ * `position: absolute` num pseudo-elemento em vez de `box-shadow` no `img`:
+ * sombra colorida acompanharia a inclinação da carta e a auréola tem que ficar
+ * parada, senão vira brilho grudado e denuncia que a carta é uma imagem plana.
+ */
 .card-center {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 18px;
+}
+
+.card-center::before {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  /* Larga o suficiente para vazar da carta sem alcançar as colunas de texto. */
+  left: 50%;
+  top: 40px;
+  width: 620px;
+  height: 620px;
+  transform: translateX(-50%);
+  pointer-events: none;
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--element, #f2c94c) 34%, transparent) 0%,
+    color-mix(in srgb, var(--element, #f2c94c) 12%, transparent) 34%,
+    transparent 68%
+  );
 }
 
 .card-aside {

--- a/components/card/CardPanel.tsx
+++ b/components/card/CardPanel.tsx
@@ -1,5 +1,4 @@
 import { ELEMENT_COLORS } from "@/lib/cards/elements";
-import { hasFoil } from "@/lib/cards/rarity";
 import type { Card } from "@/lib/cards/types";
 import { absoluteUrl } from "@/lib/config";
 import { elementKey, rarityKey, translator, type Locale } from "@/lib/i18n/dictionaries";
@@ -65,7 +64,7 @@ export function CardPanel({
           src={imagePath}
           alt={`${card.name} — ${t(elementKey(card.element))}`}
           priority
-          foil={hasFoil(card.rarity)}
+          rarity={card.rarity}
         />
         <div className="card-headline">
           <h1>{card.name}</h1>

--- a/components/card/TiltCard.tsx
+++ b/components/card/TiltCard.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef } from "react";
+import { cardTreatment, foilIntensity, hasFoil } from "@/lib/cards/rarity";
+import type { Rarity } from "@/lib/cards/types";
 
 /**
- * Carta interativa: inclinação 3D seguindo o mouse + glare radial, e a animação
- * de revelação que toca a cada visita (RFC 7.1 e 7.2).
+ * Carta interativa: inclinação 3D seguindo o mouse + pilha holográfica, e a
+ * animação de revelação que toca a cada visita (RFC 7.1 e 7.2).
  *
  * CSS 3D transform, não Three.js — decisão travada na RFC 7.1. Mais leve e já
  * validada nos dois repositórios de referência.
@@ -14,64 +16,170 @@ import { useRef, useState } from "react";
  * porcentagens entre o componente React e o renderizador (RFC 4.2, item 3); aqui
  * o problema simplesmente não existe, porque só há uma carta. O custo é que o
  * texto não é selecionável — compensado pela tabela de stats ao lado.
+ *
+ * O ponteiro **não** entra no estado do React. Um `setState` por `pointermove`
+ * re-renderiza a árvore inteira a cada movimento do mouse para escrever quatro
+ * números que só o CSS lê; aqui um laço de `requestAnimationFrame` interpola a
+ * posição e escreve direto nas custom properties do nó. A interpolação é o que dá
+ * o peso de objeto físico: sem ela a carta salta para a posição do cursor, com
+ * ela ela persegue o cursor e continua andando por alguns quadros depois que ele
+ * para.
  */
 
 const MAX_TILT = 12;
+
+/** Quanto do caminho até o alvo cada quadro percorre. Mais alto, mais seco. */
+const EASE = 0.16;
+
+/** Abaixo disto o movimento é invisível e o laço para, liberando a CPU. */
+const EPSILON = 0.0015;
+
+interface Pointer {
+  /** Posição do ponteiro dentro da carta, 0..1. */
+  px: number;
+  py: number;
+  /** 0 parado, 1 com ponteiro em cima. Interpolado junto, para acender e apagar. */
+  active: number;
+}
 
 export function TiltCard({
   src,
   alt,
   priority = false,
-  foil = false,
+  rarity,
 }: {
   src: string;
   alt: string;
   priority?: boolean;
-  /** Camada de foil especular, só nos tiers que a têm (`hasFoil`). */
-  foil?: boolean;
+  /**
+   * Define a pilha holográfica e a sua intensidade. Opcional porque a home
+   * monta as cartas de exemplo só com o caminho do PNG, sem carregar os dados —
+   * lá a carta fica lisa, com inclinação e brilho, e sem foil.
+   */
+  rarity?: Rarity;
 }) {
-  const ref = useRef<HTMLDivElement>(null);
-  const [tilt, setTilt] = useState({ x: 0, y: 0, glareX: 50, glareY: 50, active: false });
+  const cardRef = useRef<HTMLDivElement>(null);
+  const lightRef = useRef<SVGFEPointLightElement>(null);
+
+  const target = useRef<Pointer>({ px: 0.5, py: 0.5, active: 0 });
+  const current = useRef<Pointer>({ px: 0.5, py: 0.5, active: 0 });
+  const frame = useRef<number | null>(null);
+
+  // Um filtro SVG por carta: a home renderiza três, e `id` repetido faz todas
+  // usarem o filtro da primeira.
+  const filterId = `foil-${useId().replace(/:/g, "")}`;
+
+  const foil = rarity !== undefined && hasFoil(rarity);
+  const intensity = rarity === undefined ? 0 : foilIntensity(rarity);
+  const metal = rarity === undefined ? null : cardTreatment(rarity).metal;
+
+  const paint = useCallback((node: HTMLDivElement, p: Pointer) => {
+    const style = node.style;
+
+    // Mouse à direita inclina para a direita: o eixo Y gira no mesmo sentido
+    // do cursor, o eixo X no sentido inverso.
+    style.setProperty("--tilt-x", `${(0.5 - p.py) * MAX_TILT * 2}deg`);
+    style.setProperty("--tilt-y", `${(p.px - 0.5) * MAX_TILT * 2}deg`);
+    style.setProperty("--glare-x", `${p.px * 100}%`);
+    style.setProperty("--glare-y", `${p.py * 100}%`);
+    style.setProperty("--active", `${p.active}`);
+
+    /*
+     * As faixas espectrais andam **mais** que o cursor, e na diagonal. É o que
+     * separa holo de gradiente: no foil real a inclinação de poucos graus varre
+     * o espectro inteiro, porque o que se move é o ângulo de refração e não a
+     * textura. Um deslocamento 1:1 com o ponteiro lê como adesivo colado.
+     */
+    style.setProperty("--holo-shift", `${p.px * 180 - 40}%`);
+    style.setProperty("--holo-drift", `${p.py * 140 - 20}%`);
+    style.setProperty("--sheen-shift", `${(p.px * 0.6 + p.py * 0.4) * 200 - 50}%`);
+
+    // A luz especular vive em atributo SVG, que custom property nenhuma alcança.
+    const light = lightRef.current;
+    if (light) {
+      light.setAttribute("x", `${p.px * 100}`);
+      light.setAttribute("y", `${p.py * 140}`);
+    }
+  }, []);
+
+  const tick = useCallback(() => {
+    const node = cardRef.current;
+    if (!node) {
+      frame.current = null;
+      return;
+    }
+
+    const c = current.current;
+    const t = target.current;
+
+    c.px += (t.px - c.px) * EASE;
+    c.py += (t.py - c.py) * EASE;
+    c.active += (t.active - c.active) * EASE;
+
+    const settled =
+      Math.abs(t.px - c.px) < EPSILON &&
+      Math.abs(t.py - c.py) < EPSILON &&
+      Math.abs(t.active - c.active) < EPSILON;
+
+    // Encosta no alvo em vez de chegar perto: parar a 0.001 de distância deixa
+    // um resíduo de inclinação na carta em repouso.
+    if (settled) {
+      c.px = t.px;
+      c.py = t.py;
+      c.active = t.active;
+    }
+
+    paint(node, c);
+    frame.current = settled ? null : requestAnimationFrame(tick);
+  }, [paint]);
+
+  /*
+   * Sob `prefers-reduced-motion` o laço nunca roda, e é por isso que ele é a
+   * porta de entrada de tudo: escrever as custom properties uma vez que fosse
+   * deixaria valores inline no nó, que vencem a regra de media query do CSS e
+   * apagariam o brilho estático que ela monta. Não pintar nada é o que deixa o
+   * CSS no controle.
+   */
+  const start = useCallback(() => {
+    if (frame.current !== null) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    frame.current = requestAnimationFrame(tick);
+  }, [tick]);
+
+  useEffect(() => {
+    return () => {
+      if (frame.current !== null) cancelAnimationFrame(frame.current);
+    };
+  }, []);
 
   function onMove(event: React.PointerEvent<HTMLDivElement>) {
-    const node = ref.current;
+    const node = cardRef.current;
     if (!node) return;
 
     const rect = node.getBoundingClientRect();
-    const px = (event.clientX - rect.left) / rect.width;
-    const py = (event.clientY - rect.top) / rect.height;
-
-    setTilt({
-      // Mouse à direita inclina para a direita: o eixo Y gira no mesmo sentido
-      // do cursor, o eixo X no sentido inverso.
-      x: (0.5 - py) * MAX_TILT * 2,
-      y: (px - 0.5) * MAX_TILT * 2,
-      glareX: px * 100,
-      glareY: py * 100,
-      active: true,
-    });
+    target.current = {
+      px: (event.clientX - rect.left) / rect.width,
+      py: (event.clientY - rect.top) / rect.height,
+      active: 1,
+    };
+    start();
   }
 
   function reset() {
-    setTilt({ x: 0, y: 0, glareX: 50, glareY: 50, active: false });
+    target.current = { px: 0.5, py: 0.5, active: 0 };
+    start();
   }
 
   return (
     <div className="tilt-scene">
       <div
-        ref={ref}
+        ref={cardRef}
         className="tilt-card"
-        data-active={tilt.active || undefined}
+        data-foil={foil || undefined}
         onPointerMove={onMove}
         onPointerLeave={reset}
-        style={
-          {
-            "--tilt-x": `${tilt.x}deg`,
-            "--tilt-y": `${tilt.y}deg`,
-            "--glare-x": `${tilt.glareX}%`,
-            "--glare-y": `${tilt.glareY}%`,
-          } as React.CSSProperties
-        }
+        onPointerCancel={reset}
+        style={{ ["--foil" as string]: intensity }}
       >
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
@@ -81,7 +189,7 @@ export function TiltCard({
           height={700}
           fetchPriority={priority ? "high" : "auto"}
         />
-        {foil ? <SpecularFoil x={tilt.glareX} y={tilt.glareY} /> : null}
+        {foil ? <HoloFoil filterId={filterId} lightRef={lightRef} metal={metal} /> : null}
         <span className="tilt-glare" aria-hidden="true" />
       </div>
     </div>
@@ -89,13 +197,20 @@ export function TiltCard({
 }
 
 /**
- * Foil especular ao vivo, por cima do PNG do servidor (RFC 7.1).
+ * Pilha holográfica ao vivo, por cima do PNG do servidor (RFC 7.1).
  *
- * Técnica derivada do ReflectiveCard do React Bits, sem a webcam que o original
- * usa como fonte de reflexo — pedir câmera para mostrar brilho numa carta é
- * troca ruim. O que foi mantido é a pilha de filtro que faz a diferença entre
- * foil e gradiente animado: ruído procedural vira relevo por `feDisplacementMap`,
- * e `feSpecularLighting` acende esse relevo a partir de um ponto de luz.
+ * Derivada do ReflectiveCard do React Bits, sem a webcam que o original usa como
+ * fonte de reflexo — pedir câmera para mostrar brilho numa carta é troca ruim.
+ * O que foi mantido é a pilha de filtro que faz a diferença entre foil e
+ * gradiente animado: ruído procedural vira relevo, `feDisplacementMap` ondula
+ * esse relevo, e `feSpecularLighting` o acende a partir de um ponto de luz.
+ *
+ * São quatro camadas, e cada uma existe por um motivo distinto:
+ *
+ *   `tilt-foil`      relevo especular — o grão metálico que reflete
+ *   `tilt-spectral`  faixas de espectro — a cor que varre quando a carta inclina
+ *   `tilt-sheen`     lâmina diagonal — o reflexo duro da fonte de luz
+ *   `tilt-grain`     granulado fixo — tira o aspecto liso de gradiente CSS
  *
  * A luz **não** anima sozinha: `fePointLight` segue o ponteiro, reaproveitando a
  * posição que o tilt já calcula. Um brilho em loop foi exatamente o que o autor
@@ -104,35 +219,77 @@ export function TiltCard({
  *
  * Ver `docs/foil-especular.md`.
  */
-function SpecularFoil({ x, y }: { x: number; y: number }) {
+function HoloFoil({
+  filterId,
+  lightRef,
+  metal,
+}: {
+  filterId: string;
+  lightRef: React.RefObject<SVGFEPointLightElement | null>;
+  metal: "silver" | "gold" | null;
+}) {
   return (
-    <span className="tilt-foil" aria-hidden="true">
-      <svg className="tilt-foil-svg" viewBox="0 0 100 140" preserveAspectRatio="none">
-        <defs>
-          <filter id="gitmon-foil" x="0" y="0" width="100%" height="100%">
-            <feTurbulence
-              type="turbulence"
-              baseFrequency="0.9"
-              numOctaves="2"
-              seed="7"
-              result="ruido"
-            />
-            <feColorMatrix in="ruido" type="luminanceToAlpha" result="relevo" />
-            <feSpecularLighting
-              in="relevo"
-              surfaceScale="6"
-              specularConstant="1.1"
-              specularExponent="22"
-              lightingColor="#ffffff"
-              result="luz"
-            >
-              <fePointLight x={x} y={y * 1.4} z="34" />
-            </feSpecularLighting>
-            <feComposite in="luz" in2="relevo" operator="in" />
-          </filter>
-        </defs>
-        <rect width="100" height="140" filter="url(#gitmon-foil)" />
-      </svg>
+    <span className="tilt-holo" aria-hidden="true" data-metal={metal ?? undefined}>
+      <span className="tilt-foil">
+        <svg className="tilt-foil-svg" viewBox="0 0 100 140" preserveAspectRatio="none">
+          <defs>
+            {/*
+              A região passa de 100% para 140%: `feDisplacementMap` empurra pixels
+              para fora da caixa, e com a região justa a ondulação some cortada
+              nas quatro bordas — justamente onde a moldura da carta está.
+            */}
+            <filter id={filterId} x="-20%" y="-20%" width="140%" height="140%">
+              {/*
+                Frequência anisotrópica: 0.004 na horizontal contra 0.09 na
+                vertical estica o ruído em linhas. É o padrão do foil linear do
+                TCG, e a razão de não usar um ruído isotrópico aqui — ruído
+                quadrado a esta escala lê como chuvisco de televisão, não como
+                metal escovado.
+              */}
+              <feTurbulence
+                type="fractalNoise"
+                baseFrequency="0.004 0.09"
+                numOctaves="3"
+                seed="7"
+                result="grao"
+              />
+              {/* Onda lenta que serve de mapa de deslocamento para as linhas. */}
+              <feTurbulence
+                type="turbulence"
+                baseFrequency="0.021"
+                numOctaves="2"
+                seed="3"
+                result="onda"
+              />
+              <feDisplacementMap
+                in="grao"
+                in2="onda"
+                scale="16"
+                xChannelSelector="R"
+                yChannelSelector="G"
+                result="ondulado"
+              />
+              <feColorMatrix in="ondulado" type="luminanceToAlpha" result="relevo" />
+              <feSpecularLighting
+                in="relevo"
+                surfaceScale="7"
+                specularConstant="1.15"
+                specularExponent="18"
+                lightingColor="#ffffff"
+                result="luz"
+              >
+                <fePointLight ref={lightRef} x="50" y="70" z="34" />
+              </feSpecularLighting>
+              <feComposite in="luz" in2="relevo" operator="in" />
+            </filter>
+          </defs>
+          <rect width="100" height="140" filter={`url(#${filterId})`} />
+        </svg>
+      </span>
+
+      <span className="tilt-spectral" />
+      <span className="tilt-sheen" />
+      <span className="tilt-grain" />
     </span>
   );
 }

--- a/docs/foil-especular.md
+++ b/docs/foil-especular.md
@@ -20,39 +20,49 @@ feBlend           mode="screen"                                                 
 
 | Original | Aqui |
 |---|---|
-| `<video>` com webcam como camada de reflexo | camada de gradiente estático de ambiente sob o filtro |
-| `fePointLight` em posição fixa `x=0 y=0 z=300` | `x`/`y` seguem o ponteiro, reaproveitando `--glare-x` / `--glare-y` que o `TiltCard` já calcula |
+| `<video>` com webcam como camada de reflexo | nenhuma: o que está embaixo é o próprio PNG da carta |
+| `fePointLight` em posição fixa `x=0 y=0 z=300` | `x`/`y` seguem o ponteiro, reaproveitando a posição que o `TiltCard` já calcula |
 | Loop automático | sem loop: a luz só se move com o cursor |
-| Aplicado ao card inteiro como container | camada `position: absolute; inset: 0` **sobre o PNG**, dentro do `.tilt-card` existente (RFC 7.1) |
-| Sempre ativo | só quando `hasFoil(rarity)` é true — tiers `holo` e `secret` |
+| Aplicado ao card inteiro como container | camadas `position: absolute; inset: 0` **sobre o PNG**, dentro do `.tilt-card` existente (RFC 7.1) |
+| Sempre ativo | só quando `hasFoil(rarity)` é true, e com intensidade por tier (`foilIntensity`) |
 
-Camadas de apoio que valem manter do CSS original, todas por cima do PNG:
+## O que está implementado
 
-```css
-/* grão metálico */
-.reflective-noise {
-  opacity: var(--roughness, 0.4);
-  mix-blend-mode: overlay;
-  background-image: url("data:image/svg+xml,...feTurbulence baseFrequency='0.8' numOctaves='3'...");
-}
+`components/card/TiltCard.tsx` + `.tilt-*` em `app/globals.css`. Quatro camadas,
+cada uma com um trabalho distinto — a separação importa, porque foi tentar fazer
+uma camada só resolver cor **e** luz que produziu a primeira versão enevoada:
 
-/* sheen diagonal */
-.reflective-sheen {
-  background: linear-gradient(135deg,
-    rgba(255,255,255,0.4) 0%, rgba(255,255,255,0.1) 40%,
-    rgba(255,255,255,0)  50%, rgba(255,255,255,0.1) 60%,
-    rgba(255,255,255,0.3) 100%);
-  mix-blend-mode: overlay;
-  opacity: var(--metalness, 1);
-}
+| Camada | Papel | Blend |
+|---|---|---|
+| `.tilt-foil` | relevo especular (o filtro acima), mascarado em volta do ponteiro | `screen` |
+| `.tilt-spectral` | faixas de arco-íris que varrem com a inclinação | `color` |
+| `.tilt-sheen` | lâmina diagonal, o reflexo duro da fonte de luz | `overlay` |
+| `.tilt-grain` | granulado fixo, tira a lisura de gradiente CSS | `overlay` |
 
-/* borda com máscara xor — vira moldura de raridade */
-.reflective-border {
-  padding: 1px;
-  background: linear-gradient(135deg, rgba(255,255,255,0.8), rgba(255,255,255,0.2) 50%, rgba(255,255,255,0.6));
-  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  mask-composite: exclude;
-}
-```
+Duas decisões que custaram tentativa e erro:
 
-`prefers-reduced-motion: reduce` já zera transições globalmente em `app/globals.css`; a camada deve virar brilho estático, não sumir.
+- **`mix-blend-mode: color` no espectro, não `color-dodge` nem `hard-light`.** A
+  arte destas cartas é clara, e qualquer modo que some luz satura para branco e
+  enevoa nome, stats e rosto. `color` troca só matiz e saturação, preserva a
+  luminosidade do que está embaixo, e por isso o texto continua legível com a
+  carta inteira em arco-íris.
+- **O espectro e o relevo são mascarados por um radial preso ao ponteiro.**
+  Espalhados pela carta inteira eles leem como filtro de foto; concentrados num
+  ponto que se move, leem como reflexo.
+
+O `feDisplacementMap` da pilha original, que a primeira implementação tinha
+descartado, voltou — mas deslocando **ruído por ruído** (um `feTurbulence`
+anisotrópico ondulado por outro de frequência baixa), e não a `SourceGraphic`
+como no React Bits. Lá a fonte é o vídeo da webcam; aqui a fonte é um `<rect>`
+sólido, e deslocar um retângulo de cor uniforme não produz nada.
+
+A frequência anisotrópica (`baseFrequency="0.004 0.09"`) é o que dá linhas em vez
+de chuvisco: é o padrão do foil linear do TCG.
+
+## Movimento reduzido
+
+`prefers-reduced-motion: reduce` já zera transições globalmente em
+`app/globals.css`; a camada vira brilho estático, não some. Quem faz isso
+acontecer é o `TiltCard` **não escrever nada**: o laço de rAF nem começa, então
+não há custom property inline vencendo a regra de media query que monta o brilho
+parado.

--- a/lib/cards/rarity.ts
+++ b/lib/cards/rarity.ts
@@ -140,6 +140,40 @@ export function hasFoil(rarity: Rarity): boolean {
   return rarity !== "common" && rarity !== "uncommon";
 }
 
+/**
+ * Força do foil ao vivo, de 0 a 1 (`components/card/TiltCard.tsx`).
+ *
+ * O `hasFoil` acima é booleano porque a moldura impressa só precisa saber se
+ * existe arquivo de foil para compor. Na tela é diferente: seis tiers dividindo
+ * a mesma camada faz `rare` e `hyper_rare` brilharem igual, e a escada de
+ * raridade que o resto da carta constrói morre exatamente no efeito mais
+ * visível dela.
+ *
+ * Os valores não são lineares. O salto grande fica entre `double_rare` e
+ * `illustration_rare`, que é onde o tratamento também muda para full-art
+ * (`cardTreatment`) — o foil acompanha o degrau que já existe em vez de
+ * inventar outro.
+ */
+export function foilIntensity(rarity: Rarity): number {
+  switch (rarity) {
+    case "common":
+    case "uncommon":
+      return 0;
+    case "rare":
+      return 0.42;
+    case "double_rare":
+      return 0.55;
+    case "illustration_rare":
+      return 0.78;
+    case "ultra_rare":
+      return 0.88;
+    case "special_illustration_rare":
+      return 0.95;
+    case "hyper_rare":
+      return 1;
+  }
+}
+
 export type MetalTone = "silver" | "gold";
 
 export interface CardTreatment {

--- a/tests/unit/rarity.test.ts
+++ b/tests/unit/rarity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   cardTreatment,
+  foilIntensity,
   hasFoil,
   rarityForScore,
   raritySymbol,
@@ -138,5 +139,33 @@ describe("foil", () => {
 
   it("cobre seis tiers — um PNG por tier em public/assets/frames", () => {
     expect(RARITIES.filter(hasFoil)).toHaveLength(6);
+  });
+});
+
+describe("intensidade do foil ao vivo", () => {
+  it("é zero exatamente onde não há foil", () => {
+    for (const rarity of RARITIES) {
+      if (hasFoil(rarity)) expect(foilIntensity(rarity)).toBeGreaterThan(0);
+      else expect(foilIntensity(rarity)).toBe(0);
+    }
+  });
+
+  /*
+   * O ponto da função. Se dois tiers empatarem, a escada de raridade morre no
+   * efeito mais visível que a carta tem — que foi o estado anterior, com um
+   * booleano decidindo o brilho de seis tiers.
+   */
+  it("cresce estritamente entre os tiers com foil", () => {
+    const valores = RARITIES.filter(hasFoil).map(foilIntensity);
+    for (let i = 1; i < valores.length; i += 1) {
+      expect(valores[i]).toBeGreaterThan(valores[i - 1]);
+    }
+  });
+
+  it("fica no intervalo que o CSS multiplica, sem estourar as opacidades", () => {
+    for (const rarity of RARITIES) {
+      expect(foilIntensity(rarity)).toBeGreaterThanOrEqual(0);
+      expect(foilIntensity(rarity)).toBeLessThanOrEqual(1);
+    }
   });
 });


### PR DESCRIPTION
Empilhada sobre #1 -- a base e `feat/tipos-18-raridade-e-status`, entao o diff aqui e so dos dois commits desta sessao.

## O tilt 3D estava morto desde que foi escrito

`.tilt-card` declarava `animation: reveal ... both`. Com `fill-mode: both` o quadro 100% da revelacao (`transform: none`) continua valendo depois que a animacao termina, e no CSS animacao vence declaracao normal na cascata. O `transform: rotateX(var(--tilt-x)) rotateY(var(--tilt-y))` da mesma regra nunca chegava a ser aplicado.

E um bug que nao aparece em teste nem em review: o componente calcula os angulos certos, escreve as custom properties certas, o `data-active` entra no DOM, e a carta nao se mexe. Medido no navegador com o ponteiro sobre a carta, antes da correcao:

```
tiltX: '4.8deg'   tiltY: '4.8deg'   transform: 'matrix(1, 0, 0, 1, 0, 0)'
```

`backwards` cobre exatamente o que o `both` existia para cobrir e devolve o controle do transform quando a revelacao acaba.

## O foil virou holo

Era uma camada so: relevo especular branco sobre o PNG. Isso da brilho, nao holo -- foil de TCG e antes de tudo *cor* varrendo a superficie, e nao havia cor nenhuma. O `docs/foil-especular.md` ja descrevia sheen, granulado, borda e um `feDisplacementMap` que nunca chegaram ao codigo.

| Camada | Papel | Blend |
|---|---|---|
| `.tilt-foil` | relevo especular, mascarado em volta do ponteiro | `screen` |
| `.tilt-spectral` | faixas de arco-iris que varrem com a inclinacao | `color` |
| `.tilt-sheen` | lamina diagonal, o reflexo duro da fonte de luz | `overlay` |
| `.tilt-grain` | granulado fixo, tira a lisura de gradiente CSS | `overlay` |

Duas decisoes custaram tentativa e erro:

- **`mix-blend-mode: color`, nao `color-dodge` nem `hard-light`.** A arte destas cartas e clara, e qualquer modo que soma luz satura para branco -- as duas primeiras versoes enevoaram rosto, nome e stats. `color` troca so matiz e saturacao e preserva a luminosidade de baixo, entao o texto preto continua preto com a carta inteira em arco-iris. Cor e luz viram camadas separadas.
- **Espectro e relevo mascarados por um radial preso ao ponteiro.** Espalhados pela carta inteira leem como filtro de foto; concentrados num ponto que se move, leem como reflexo.

O `feDisplacementMap` volta deslocando ruido por ruido, e nao a `SourceGraphic` como no React Bits -- la a fonte e o video da webcam, aqui e um `<rect>` solido, e deslocar retangulo de cor uniforme nao produz nada.

## Resto

- `foilIntensity()` escala o foil por tier: seis tiers dividindo a mesma camada brilhavam igual, e a escada de raridade morria no efeito mais visivel dela.
- O ponteiro saiu do estado do React -- era um `setState` por `pointermove` para escrever quatro numeros que so o CSS le. Agora e um laco de `requestAnimationFrame` interpolando direto nas custom properties. A interpolacao e o que da peso de objeto fisico.
- Aureola do elemento atras da carta: `--element` ja existia, mas so aparecia em texto de 13px, e a pagina saia identica para os 18 tipos.

## Verificacao

106 testes unitarios (eram 103), 13 e2e, typecheck limpo.

Conferido ao vivo em `/torvalds` (hiper rara, arte clara) e `/facebook/react` (rara ilustrada especial, arte escura), mais movimento reduzido, 390px e a home.

Sobre movimento reduzido: o foil vira brilho estatico em vez de sumir, como o doc pede. Quem faz isso acontecer e o `TiltCard` **nao escrever nada** -- o laco nem comeca, entao nao ha custom property inline vencendo a regra de media query.

Nota sobre a suite e2e: houve falhas intermitentes logo apos as edicoes. Investigadas em vez de assumidas como flake -- com as mudancas guardadas no stash a suite passou, e restauradas passou tres vezes seguidas com o dev server quente. Eram corridas de compilacao a frio do Turbopack, nao regressao.