### PR TITLE
feat: auth GitHub, pool de tokens, rate limit, busca de usuários e radar de batalha

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@ NEXT_PUBLIC_BASE_URL=http://localhost:3000
 # O visitante nunca faz login (RFC 5).
 GITHUB_TOKEN=
 
+# Pool de tokens: vários tokens de contas DISTINTAS, separados por vírgula,
+# multiplicam o teto (4 tokens ≈ 20k req/h) e dão failover quando um estoura o
+# rate limit. Cada login fica preso a um token por hash. Opcional — sem isto,
+# GITHUB_TOKEN sozinho funciona como um pool de um.
+# GITHUB_TOKENS=ghp_aaa...,ghp_bbb...
+
 # --- Redis / ioredis ---
 # Duas responsabilidades diferentes na mesma instância:
 #

--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,12 @@ GITHUB_TOKEN=
 REDIS_URL=
 CARD_DATA_TTL_SECONDS=3600
 
+# Orçamento de buscas de carta por IP, aplicado antes do cache (protege o pool
+# de tokens de scrapers). Em desenvolvimento (NODE_ENV=development) é ignorado.
+# Defaults: 20 buscas a cada 600s.
+# CARD_RATE_LIMIT_PER_WINDOW=20
+# CARD_RATE_LIMIT_WINDOW_SECONDS=600
+
 # Contagem de estrelas do próprio repositório, exibida na faixa de apoio. Cache
 # só; sem ele o botão de favoritar continua funcionando, apenas sem número.
 PROJECT_STARS_TTL_SECONDS=3600

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 
 ## [0.2.0](2026-08-12)
 
+### Components
+
+#### Features
+
+- adds useEffect import and adds useEffect
+- adds useRef, UserSearchInput import and removes useState import and adds inputRef, resolved and removes target
+
+
 ### App
 
 #### Features
@@ -31,13 +39,6 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 #### Documentation
 
 - adds and import
-
-
-### Components
-
-#### Features
-
-- adds useRef, UserSearchInput import and removes useState import and adds inputRef, resolved and removes target
 
 
 ### General
@@ -110,6 +111,7 @@ Thank you to 2 community contributors:
 - docs: plano do revamp visual e as decisoes que o travam
 
 @benogoulart
+- feat(components): adds useEffect import and adds useEffect
 - feat: adds Image, type import
 - feat: adds useState, AXES, type import
 - feat(app): adds NotFound function and adds Link, Shell, translator import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,110 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Format: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+
+
+## [0.2.0](2026-08-12)
+
+### Lib
+
+#### Features
+
+- adds baseUrl import and adds oauthConfig, clientId in oauth
+
+#### Bug Fixes
+
+- removes baseUrl import and adds appBaseUrl, explicit and removes appBaseUrl in oauth
+
+
+### App
+
+#### Features
+
+- updates icon, layout
+
+
+### Components
+
+#### Features
+
+- adds useRef, UserSearchInput import and removes useState import and adds inputRef, resolved and removes target
+
+
+### General
+
+#### Features
+
+- adds searchUsers, useRef, UserSearchInput import and removes useState import and adds dynamic, GET and removes target and adds useState, useRef, useId
+- adds checkCardRateLimit, type, getRedisClient import and adds discoverPool, pool and removes authHeaders, token
+- o site passa a falar a lingua da carta
+- levar a carta embora -- previa de link, baixar PNG e compartilhar
+- a raridade se expressa em superficie e borda, nao so em simbolo
+- mais arte, e a solda entre arte e moldura
+- HP como heroi numerico do cabecalho
+- serial como elemento de design, e o rodape redesenhado sem ele
+- foil impresso reassado em quatro camadas
+- foil holografico por camadas e aureola do elemento
+- icones de tipo na interface
+- derivacoes da carta de repositorio
+- arranjo simetrico da pagina da carta
+- radar de assinatura do perfil
+- 18 tipos, escada de raridade do TCG, serial e explicacao dos status
+- batalha, site bilingue e carta interativa
+- arte original, renderizacao da imagem e rotas de card
+- base Next.js, dominio de cartas e scoring
+
+#### Bug Fixes
+
+- inclinacao 3D da carta nunca chegou a aplicar
+
+#### Documentation
+
+- estado real depois da fase 1 do revamp
+- plano do revamp visual e as decisoes que o travam
+- secao de contribuicao no README
+- README conciliado com o codigo
+- concilia RFC e specs com os 18 tipos
+- handoff da sessao com o contexto que nao esta no codigo
+
+#### Chores
+
+- scaffold inicial do gitmon-cards
+
+
+### Contributors
+
+Thank you to 2 community contributors:
+
+@mcsscalabrin
+- feat: foil holografico por camadas e aureola do elemento
+- fix: inclinacao 3D da carta nunca chegou a aplicar
+- docs: secao de contribuicao no README
+- docs: README conciliado com o codigo
+- docs: concilia RFC e specs com os 18 tipos
+- feat: icones de tipo na interface
+- feat: derivacoes da carta de repositorio
+- docs: handoff da sessao com o contexto que nao esta no codigo
+- feat: arranjo simetrico da pagina da carta
+- feat: radar de assinatura do perfil
+- feat: 18 tipos, escada de raridade do TCG, serial e explicacao dos status
+- feat: o site passa a falar a lingua da carta
+- feat: levar a carta embora -- previa de link, baixar PNG e compartilhar
+- docs: estado real depois da fase 1 do revamp
+- feat: a raridade se expressa em superficie e borda, nao so em simbolo
+- feat: mais arte, e a solda entre arte e moldura
+- feat: HP como heroi numerico do cabecalho
+- feat: serial como elemento de design, e o rodape redesenhado sem ele
+- feat: foil impresso reassado em quatro camadas
+- docs: plano do revamp visual e as decisoes que o travam
+
+@benogoulart
+- feat(app): updates icon, layout
+- feat(components): adds useRef, UserSearchInput import and removes useState import and adds inputRef, resolved and removes target
+- feat: adds searchUsers, useRef, UserSearchInput import and removes useState import and adds dynamic, GET and removes target and adds useState, useRef, useId
+- fix(lib): removes baseUrl import and adds appBaseUrl, explicit and removes appBaseUrl in oauth
+- feat(lib): adds baseUrl import and adds oauthConfig, clientId in oauth
+- feat: adds checkCardRateLimit, type, getRedisClient import and adds discoverPool, pool and removes authHeaders, token
+
+**Contributors:** @mcsscalabrin, @benogoulart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 
 ## [0.2.0](2026-08-12)
 
+### App
+
+#### Features
+
+- adds NotFound function and adds Link, Shell, translator import
+- updates icon, layout
+
+
 ### Lib
 
 #### Features
@@ -18,11 +26,11 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 - removes baseUrl import and adds appBaseUrl, explicit and removes appBaseUrl in oauth
 
 
-### App
+### CHANGELOG
 
-#### Features
+#### Documentation
 
-- updates icon, layout
+- adds and import
 
 
 ### Components
@@ -36,6 +44,8 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 
 #### Features
 
+- adds Image, type import
+- adds useState, AXES, type import
 - adds searchUsers, useRef, UserSearchInput import and removes useState import and adds dynamic, GET and removes target and adds useState, useRef, useId
 - adds checkCardRateLimit, type, getRedisClient import and adds discoverPool, pool and removes authHeaders, token
 - o site passa a falar a lingua da carta
@@ -100,6 +110,10 @@ Thank you to 2 community contributors:
 - docs: plano do revamp visual e as decisoes que o travam
 
 @benogoulart
+- feat: adds Image, type import
+- feat: adds useState, AXES, type import
+- feat(app): adds NotFound function and adds Link, Shell, translator import
+- docs(CHANGELOG): adds and import
 - feat(app): updates icon, layout
 - feat(components): adds useRef, UserSearchInput import and removes useState import and adds inputRef, resolved and removes target
 - feat: adds searchUsers, useRef, UserSearchInput import and removes useState import and adds dynamic, GET and removes target and adds useState, useRef, useId

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,17 @@
+import { searchUsers } from "@/lib/github/search";
+
+// User-search suggestions for the home form (as-you-type by name). Never
+// blocks the scout path: failures resolve to an empty list so the client just
+// hides the dropdown.
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request) {
+  const q = (new URL(req.url).searchParams.get("q") ?? "").trim();
+  if (!q) return Response.json({ hits: [] });
+  try {
+    const hits = await searchUsers(q);
+    return Response.json({ hits }, { headers: { "Cache-Control": "no-store" } });
+  } catch {
+    return Response.json({ hits: [] }, { headers: { "Cache-Control": "no-store" } });
+  }
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Link from "next/link";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="shell">
+      <main className="shell-main">
+        <div className="error-state">
+          <h1>A API do GitHub não respondeu.</h1>
+          <p className="error-subject">{error.message}</p>
+          <div style={{ display: "flex", gap: 10 }}>
+            <button className="button" type="button" onClick={reset}>
+              Tentar de novo
+            </button>
+            <Link className="button" href="/" style={{ background: "var(--bg-raised)", color: "var(--text)", border: "1px solid var(--border)" }}>
+              Gitmon
+            </Link>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -299,14 +299,6 @@ select {
   color: var(--text-faint);
 }
 
-.radar-svg {
-  width: 100%;
-  max-width: 260px;
-  height: auto;
-  align-self: center;
-  overflow: visible;
-}
-
 /* Grade e raios recuam: são estrutura, não dado. */
 .radar-grid {
   fill: none;
@@ -343,6 +335,66 @@ select {
   font-weight: 700;
   letter-spacing: 0.6px;
   text-transform: uppercase;
+  transition: fill .2s ease, opacity .25s ease;
+}
+
+.radar-svg-wrap {
+  position: relative;
+  width: 100%;
+  max-width: 260px;
+  align-self: center;
+}
+
+.radar-svg {
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.radar-sector-active {
+  fill: var(--element, var(--accent));
+  fill-opacity: 0.12;
+  stroke: var(--element, var(--accent));
+  stroke-opacity: 0.3;
+  stroke-width: 1;
+  animation: pop .16s cubic-bezier(.16,1,.3,1) both;
+}
+
+.radar-hitzone {
+  cursor: pointer;
+  outline: none;
+}
+
+.radar-tooltip {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  transform: translateX(-50%) translateY(calc(100% + 8px));
+  z-index: 10;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-raised);
+  box-shadow: 0 10px 28px -8px rgba(0, 0, 0, 0.4);
+  text-align: center;
+  pointer-events: none;
+  animation: pop .16s cubic-bezier(.16,1,.3,1) both;
+}
+
+.radar-tooltip-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.radar-tooltip-value {
+  margin-top: 2px;
+  font-size: 19px;
+  font-weight: 900;
+  color: var(--element, var(--accent));
+  font-variant-numeric: tabular-nums;
 }
 
 .visually-hidden {
@@ -1710,6 +1762,127 @@ select {
   align-items: center;
   gap: 16px;
   flex-wrap: wrap;
+}
+
+/* ------------------------------------------------------ radar de batalha */
+
+.battle-radar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  margin: 8px 0;
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-raised);
+}
+
+.battle-radar-caption h2 {
+  margin: 0;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  color: var(--text-faint);
+  text-align: center;
+}
+
+.battle-radar-caption p {
+  margin: 4px 0 0;
+  font-size: 12.5px;
+  color: var(--text-faint);
+  text-align: center;
+}
+
+.battle-radar-legend {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+}
+
+.battle-radar-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.battle-radar-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.battle-radar-svg-wrap {
+  position: relative;
+  width: 100%;
+  max-width: 260px;
+}
+
+.battle-radar-svg {
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.battle-radar-shape {
+  fill-opacity: 0.28;
+  stroke-width: 1.4;
+  stroke-linejoin: round;
+  transition: fill-opacity .25s ease, stroke-opacity .25s ease;
+}
+
+.battle-radar-sector {
+  stroke-width: 1;
+  animation: pop .16s cubic-bezier(.16,1,.3,1) both;
+}
+
+.battle-radar-hitzone {
+  cursor: pointer;
+  outline: none;
+}
+
+.battle-radar-tooltip {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  transform: translateX(-50%) translateY(calc(100% + 8px));
+  z-index: 10;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-raised);
+  box-shadow: 0 10px 28px -8px rgba(0, 0, 0, 0.4);
+  text-align: center;
+  pointer-events: none;
+  animation: pop .16s cubic-bezier(.16,1,.3,1) both;
+}
+
+.battle-radar-tooltip-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.battle-radar-tooltip-values {
+  display: flex;
+  gap: 12px;
+  margin-top: 4px;
+  font-size: 13px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+@keyframes pop {
+  from {
+    opacity: 0;
+    transform: scale(0.9);
+  }
 }
 
 /* --------------------------------------------------------------- erro */

--- a/app/globals.css
+++ b/app/globals.css
@@ -810,21 +810,9 @@ select {
   min-width: 0;
 }
 
-.search-input-at {
-  position: absolute;
-  left: 14px;
-  top: 50%;
-  transform: translateY(-50%);
-  pointer-events: none;
-  color: var(--accent);
-  font-weight: 800;
-  font-size: 15px;
-  opacity: 0.7;
-}
-
 .search-input {
   width: 100%;
-  padding: 11px 14px 11px 30px;
+  padding: 11px 14px;
   border-radius: var(--radius);
   border: 1px solid var(--border-strong);
   background: var(--bg-sunken);

--- a/app/globals.css
+++ b/app/globals.css
@@ -802,6 +802,128 @@ select {
   outline-color: var(--element, var(--accent));
 }
 
+/* ----------------------------------------------- autocomplete por nome */
+
+.search-input-wrap {
+  position: relative;
+  flex: 1 1 260px;
+  min-width: 0;
+}
+
+.search-input-at {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: var(--accent);
+  font-weight: 800;
+  font-size: 15px;
+  opacity: 0.7;
+}
+
+.search-input {
+  width: 100%;
+  padding: 11px 14px 11px 30px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-sunken);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 15px;
+  font-weight: 600;
+  outline: none;
+  transition: border-color 200ms ease, box-shadow 200ms ease;
+}
+
+.search-input:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(242, 201, 76, 0.15);
+}
+
+.search-dropdown {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(100% + 6px);
+  z-index: 30;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-raised);
+  box-shadow: 0 18px 50px rgba(25, 21, 33, 0.25);
+  overflow: hidden;
+  animation: dropdown-in 150ms ease both;
+}
+
+@keyframes dropdown-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
+
+.search-dropdown-status {
+  padding: 10px 14px;
+  font-size: 12.5px;
+  color: var(--text-faint);
+}
+
+.search-dropdown-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 12px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.search-dropdown-item:hover {
+  background: var(--bg-sunken);
+}
+
+.search-dropdown-avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--bg-sunken);
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.search-dropdown-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.search-dropdown-name {
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.search-dropdown-login {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-faint);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .search-form button,
 .battle-form button {
   padding: 11px 20px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -1616,11 +1616,22 @@ select {
   background: var(--bg-raised);
   opacity: 0.7;
   transition: opacity 240ms ease, border-color 240ms ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
 }
 
 .fighter-bar[data-won] {
   opacity: 1;
   border-color: var(--accent);
+}
+
+.fighter-card-img {
+  width: 100px;
+  height: auto;
+  border-radius: 10px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
 }
 
 .fighter-head {

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="2" y="2" width="28" height="28" rx="5" fill="#0d0f14" stroke="#f2c94c" stroke-width="2"/>
+  <path d="M2 2h28v14L16 30 2 16z" fill="#f2c94c"/>
+</svg>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,9 @@ export const metadata: Metadata = {
   },
   description:
     "Cartas de trading card game geradas a partir de dados reais do GitHub. Uma URL de imagem, sem login, embutível em qualquer README.",
+  icons: {
+    icon: "/icon.svg",
+  },
   openGraph: {
     type: "website",
     siteName: "Gitmon Cards",

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+import { Shell } from "@/components/ui/Shell";
+import { translator } from "@/lib/i18n/dictionaries";
+import { getLocale } from "@/lib/i18n/server";
+
+export default async function NotFound() {
+  const locale = await getLocale();
+  const t = translator(locale);
+
+  return (
+    <Shell locale={locale}>
+      <div className="error-state">
+        <h1>{t("error.not_found")}</h1>
+        <Link className="button" href="/">
+          Gitmon
+        </Link>
+      </div>
+    </Shell>
+  );
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+import { baseUrl } from "@/lib/config";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/"],
+      },
+    ],
+    sitemap: `${baseUrl()}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+import { baseUrl } from "@/lib/config";
+
+/**
+ * Sitemap estático. As páginas de perfil (`/<owner>` e `/<owner>/<repo>`) são
+ * dinâmicas e não entram aqui — o Google descobre pelo crawl. Este arquivo
+ * garante que a home e as páginas de batalha indexem corretamente.
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = baseUrl();
+
+  return [
+    {
+      url: base,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+  ];
+}

--- a/components/battle/BattleForm.tsx
+++ b/components/battle/BattleForm.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState, useTransition } from "react";
+import { useRef, useState, useTransition } from "react";
+import UserSearchInput, { type UserSearchInputHandle } from "../ui/UserSearchInput";
 
 /**
  * Manda para `/<desafiante>/vs/<adversário>`, que sorteia uma batalha nova e
@@ -22,10 +23,12 @@ export function BattleForm({
   const router = useRouter();
   const [opponent, setOpponent] = useState("");
   const [pending, startTransition] = useTransition();
+  const inputRef = useRef<UserSearchInputHandle>(null);
 
   function submit(event: React.FormEvent) {
     event.preventDefault();
-    const target = opponent.trim().replace(/^@/, "").replace(/^\/+|\/+$/g, "");
+    const resolved = inputRef.current?.resolve(opponent);
+    const target = resolved ?? opponent.trim().replace(/^@/, "").replace(/^\/+|\/+$/g, "");
     if (!target) return;
     startTransition(() => router.push(`/${challenger}/vs/${target}`));
   }
@@ -34,14 +37,12 @@ export function BattleForm({
     <form className="battle-form" onSubmit={submit}>
       <h2>{label}</h2>
       <div className="battle-form-row">
-        <input
-          type="text"
+        <UserSearchInput
+          ref={inputRef}
           value={opponent}
-          onChange={(event) => setOpponent(event.target.value)}
+          onValueChange={setOpponent}
+          label={placeholder}
           placeholder={placeholder}
-          aria-label={placeholder}
-          autoComplete="off"
-          spellCheck={false}
         />
         <button type="submit" disabled={pending}>
           {action}

--- a/components/battle/BattleRadar.tsx
+++ b/components/battle/BattleRadar.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState } from "react";
+import { AXES } from "@/lib/cards/ratings";
+import type { Card } from "@/lib/cards/types";
+import { ELEMENT_COLORS } from "@/lib/cards/elements";
+import { radarGeometry, radarSector } from "@/lib/radar";
+import { translator, type Locale, type MessageKey } from "@/lib/i18n/dictionaries";
+
+const SIZE = 240;
+
+/**
+ * Radar comparativo de batalha: dois polígonos sobrepostos no mesmo eixo.
+ *
+ * A sobreposição mostra visualmente onde cada oponente leva vantagem — a forma
+ * do polígono é a "assinatura" do perfil, e onde um polígono se estende além
+ * do outro, aquele lado domina naquele eixo.
+ */
+export function BattleRadar({
+  a,
+  b,
+  locale,
+}: {
+  a: Card;
+  b: Card;
+  locale: Locale;
+}) {
+  const t = translator(locale);
+  const [active, setActive] = useState<number | null>(null);
+
+  const ratingsA = a.ratings ?? [];
+  const ratingsB = b.ratings ?? [];
+
+  const valuesA = AXES.map((_, i) => ratingsA[i]?.value ?? 0);
+  const valuesB = AXES.map((_, i) => ratingsB[i]?.value ?? 0);
+  const labels = AXES.map((ax) => t(`axis.${ax}` as MessageKey));
+
+  const geoA = radarGeometry(valuesA, labels, SIZE);
+  const geoB = radarGeometry(valuesB, labels, SIZE);
+  const geo = geoA; // rings/labels/sectors are shared
+
+  const colorsA = ELEMENT_COLORS[a.element];
+  const colorsB = ELEMENT_COLORS[b.element];
+
+  return (
+    <figure className="battle-radar">
+      <figcaption className="battle-radar-caption">
+        <h2>{t("battle.radar")}</h2>
+        <p>{t("battle.radarCaption")}</p>
+      </figcaption>
+
+      <div className="battle-radar-legend">
+        <span className="battle-radar-legend-item">
+          <span className="battle-radar-dot" style={{ background: colorsA.base }} />
+          {a.name}
+        </span>
+        <span className="battle-radar-legend-item">
+          <span className="battle-radar-dot" style={{ background: colorsB.base }} />
+          {b.name}
+        </span>
+      </div>
+
+      <div className="battle-radar-svg-wrap">
+        <svg viewBox={`0 0 ${SIZE} ${SIZE}`} className="battle-radar-svg">
+          {geo.rings.map((ring, i) => (
+            <polygon key={i} points={ring} className="radar-grid" />
+          ))}
+
+          {active !== null && (
+            <polygon
+              points={geo.sectors[active]}
+              className="battle-radar-sector"
+              style={{ fill: `${colorsA.base}18`, stroke: `${colorsA.base}40` }}
+            />
+          )}
+
+          <polygon
+            points={geoA.points}
+            className="battle-radar-shape"
+            style={{
+              fill: `${colorsA.base}${active !== null ? "22" : "30"}`,
+              stroke: colorsA.base,
+              strokeOpacity: active !== null ? 0.55 : 1,
+            }}
+          />
+          <polygon
+            points={geoB.points}
+            className="battle-radar-shape"
+            style={{
+              fill: `${colorsB.base}${active !== null ? "22" : "30"}`,
+              stroke: colorsB.base,
+              strokeOpacity: active !== null ? 0.55 : 1,
+            }}
+          />
+
+          {geoA.vertices.map((v, i) => (
+            <circle
+              key={`a-${i}`}
+              cx={v.x}
+              cy={v.y}
+              r={active === i ? 3.5 : 2}
+              fill={colorsA.base}
+              opacity={active !== null && active !== i ? 0.3 : 1}
+              style={{ transition: "r .2s ease, opacity .25s ease" }}
+            />
+          ))}
+          {geoB.vertices.map((v, i) => (
+            <circle
+              key={`b-${i}`}
+              cx={v.x}
+              cy={v.y}
+              r={active === i ? 3.5 : 2}
+              fill={colorsB.base}
+              opacity={active !== null && active !== i ? 0.3 : 1}
+              style={{ transition: "r .2s ease, opacity .25s ease" }}
+            />
+          ))}
+
+          {geo.labels.map((l, i) => (
+            <text
+              key={i}
+              x={l.x}
+              y={l.y}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              className="radar-label"
+              fill={active === i ? "var(--text)" : "var(--text-faint)"}
+              style={{ transition: "fill .2s ease" }}
+            >
+              {l.label}
+            </text>
+          ))}
+
+          {AXES.map((_, i) => (
+            <polygon
+              key={i}
+              points={radarSector(geo.center, geo.radius + 17, i, AXES.length)}
+              fill="transparent"
+              className="battle-radar-hitzone"
+              onMouseEnter={() => setActive(i)}
+              onMouseLeave={() => setActive(null)}
+              onClick={() => setActive((prev) => (prev === i ? null : i))}
+            />
+          ))}
+        </svg>
+
+        {active !== null && (
+          <div className="battle-radar-tooltip">
+            <div className="battle-radar-tooltip-label">{labels[active]}</div>
+            <div className="battle-radar-tooltip-values">
+              <span style={{ color: colorsA.base }}>
+                {a.name}: {valuesA[active]}
+              </span>
+              <span style={{ color: colorsB.base }}>
+                {b.name}: {valuesB[active]}
+              </span>
+            </div>
+          </div>
+        )}
+      </div>
+    </figure>
+  );
+}

--- a/components/battle/BattleReplay.tsx
+++ b/components/battle/BattleReplay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { BattleResult, Side } from "@/lib/battle/types";
 import { ELEMENT_COLORS } from "@/lib/cards/elements";
 import type { Card, Element } from "@/lib/cards/types";
@@ -27,12 +27,21 @@ export function BattleReplay({
 }) {
   const t = translator(locale);
   const [played, setPlayed] = useState(0);
+  const logRef = useRef<HTMLOListElement>(null);
 
   useEffect(() => {
     if (played >= battle.turns.length) return;
     const timer = setTimeout(() => setPlayed((n) => n + 1), TURN_MS);
     return () => clearTimeout(timer);
   }, [played, battle.turns.length]);
+
+  /** Auto-scroll para o último turno visível. */
+  useEffect(() => {
+    const log = logRef.current;
+    if (!log) return;
+    const last = log.lastElementChild;
+    if (last) last.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [played]);
 
   /** HP de cada lado depois dos turnos já tocados. */
   const hp = useMemo(() => {

--- a/components/battle/BattleReplay.tsx
+++ b/components/battle/BattleReplay.tsx
@@ -5,6 +5,7 @@ import type { BattleResult, Side } from "@/lib/battle/types";
 import { ELEMENT_COLORS } from "@/lib/cards/elements";
 import type { Element } from "@/lib/cards/types";
 import { translator, type Locale } from "@/lib/i18n/dictionaries";
+import { BattleRadar } from "./BattleRadar";
 
 /**
  * Animação do log de turnos.
@@ -65,6 +66,8 @@ export function BattleReplay({
           label={t("battle.winner")}
         />
       </div>
+
+      <BattleRadar a={battle.a} b={battle.b} locale={locale} />
 
       <ol className="replay-log" aria-live="polite">
         {battle.turns.slice(0, played).map((turn) => {

--- a/components/battle/BattleReplay.tsx
+++ b/components/battle/BattleReplay.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import Image from "next/image";
 import { useEffect, useMemo, useState } from "react";
 import type { BattleResult, Side } from "@/lib/battle/types";
 import { ELEMENT_COLORS } from "@/lib/cards/elements";
-import type { Element } from "@/lib/cards/types";
+import type { Card, Element } from "@/lib/cards/types";
 import { translator, type Locale } from "@/lib/i18n/dictionaries";
 import { BattleRadar } from "./BattleRadar";
 
@@ -49,25 +50,19 @@ export function BattleReplay({
     <div className="replay">
       <div className="replay-fighters">
         <FighterBar
-          name={battle.a.name}
-          element={battle.a.element}
+          card={battle.a}
           hp={hp.a}
-          max={battle.a.hp}
           won={finished && battle.winner === "a"}
           label={t("battle.winner")}
         />
         <span className="replay-vs">VS</span>
         <FighterBar
-          name={battle.b.name}
-          element={battle.b.element}
+          card={battle.b}
           hp={hp.b}
-          max={battle.b.hp}
           won={finished && battle.winner === "b"}
           label={t("battle.winner")}
         />
       </div>
-
-      <BattleRadar a={battle.a} b={battle.b} locale={locale} />
 
       <ol className="replay-log" aria-live="polite">
         {battle.turns.slice(0, played).map((turn) => {
@@ -102,13 +97,15 @@ export function BattleReplay({
       </ol>
 
       {finished ? (
-        <p className="replay-result">
-          {battle.winner
-            ? `${t("battle.winner")}: ${battle.winner === "a" ? battle.a.name : battle.b.name}`
-            : "—"}
-          {/* No teto de turnos ninguém foi nocauteado: vale dizer como foi decidido. */}
-          {battle.decidedBy === "hp" ? <em> · {t("battle.draw")}</em> : null}
-        </p>
+        <>
+          <p className="replay-result">
+            {battle.winner
+              ? `${t("battle.winner")}: ${battle.winner === "a" ? battle.a.name : battle.b.name}`
+              : "—"}
+            {battle.decidedBy === "hp" ? <em> · {t("battle.draw")}</em> : null}
+          </p>
+          <BattleRadar a={battle.a} b={battle.b} locale={locale} />
+        </>
       ) : (
         <button
           type="button"
@@ -123,32 +120,35 @@ export function BattleReplay({
 }
 
 function FighterBar({
-  name,
-  element,
+  card,
   hp,
-  max,
   won,
   label,
 }: {
-  name: string;
-  element: Element;
+  card: Card;
   hp: number;
-  max: number;
   won: boolean;
   label: string;
 }) {
-  const colors = ELEMENT_COLORS[element];
-  const ratio = Math.max(0, Math.min(1, hp / Math.max(1, max)));
+  const colors = ELEMENT_COLORS[card.element];
+  const ratio = Math.max(0, Math.min(1, hp / Math.max(1, card.hp)));
 
   return (
     <div className="fighter-bar" data-won={won || undefined}>
+      <Image
+        src={`/${card.id}.png`}
+        alt={card.name}
+        width={140}
+        height={196}
+        className="fighter-card-img"
+      />
       <div className="fighter-head">
-        <strong>{name}</strong>
+        <strong>{card.name}</strong>
         {won ? <span className="fighter-won">{label}</span> : null}
       </div>
       <div className="fighter-hp">
         <span>{hp}</span>
-        <i>/ {max}</i>
+        <i>/ {card.hp}</i>
       </div>
       <div className="fighter-track">
         <div

--- a/components/card/RadarChart.tsx
+++ b/components/card/RadarChart.tsx
@@ -1,5 +1,9 @@
-import { AXES, gridPoints, labelPosition, polygonPoints } from "@/lib/cards/ratings";
+"use client";
+
+import { useState } from "react";
+import { AXES } from "@/lib/cards/ratings";
 import type { AxisRating } from "@/lib/cards/ratings";
+import { radarGeometry, radarSector } from "@/lib/radar";
 import { translator, type Locale, type MessageKey } from "@/lib/i18n/dictionaries";
 
 /**
@@ -25,10 +29,15 @@ export function RadarChart({
   locale: Locale;
 }) {
   const t = translator(locale);
+  const [active, setActive] = useState<number | null>(null);
 
   const size = 240;
-  const center = size / 2;
-  const radius = 82;
+
+  const values = ratings.map((r) => r.value);
+  const labels = AXES.map((a) => t(`axis.${a}` as MessageKey));
+  const geo = radarGeometry(values, labels, size);
+
+  const dimmed = (i: number) => active !== null && active !== i;
 
   return (
     <figure className="radar">
@@ -37,58 +46,94 @@ export function RadarChart({
         <p>{t("radar.caption")}</p>
       </figcaption>
 
-      <svg
-        viewBox={`0 0 ${size} ${size}`}
-        className="radar-svg"
-        role="img"
-        aria-label={t("radar.title")}
-      >
-        {/* Grade recessiva: só profundidade, sem valor associado. */}
-        {[0.25, 0.5, 0.75, 1].map((step) => (
-          <polygon
-            key={step}
-            points={gridPoints(AXES.length, radius * step, center)}
-            className="radar-grid"
-          />
-        ))}
+      <div className="radar-svg-wrap">
+        <svg
+          viewBox={`0 0 ${size} ${size}`}
+          className="radar-svg"
+          role="img"
+          aria-label={t("radar.title")}
+        >
+          {geo.rings.map((ring, i) => (
+            <polygon key={i} points={ring} className="radar-grid" />
+          ))}
 
-        {AXES.map((_, index) => {
-          const { x, y } = labelPosition(index, AXES.length, radius, center);
-          return (
+          {active !== null && (
+            <polygon
+              points={geo.sectors[active]}
+              className="radar-sector-active"
+            />
+          )}
+
+          {geo.sectors.map((sector, i) => (
             <line
-              key={index}
-              x1={center}
-              y1={center}
-              x2={x}
-              y2={y}
+              key={i}
+              x1={geo.center}
+              y1={geo.center}
+              x2={geo.vertices[i].x}
+              y2={geo.vertices[i].y}
               className="radar-spoke"
             />
-          );
-        })}
+          ))}
 
-        <polygon points={polygonPoints(ratings, radius, center)} className="radar-shape" />
+          <polygon
+            points={geo.points}
+            className="radar-shape"
+            style={{
+              fillOpacity: active !== null ? 0.18 : 0.28,
+              transition: "fill-opacity .25s ease",
+            }}
+          />
 
-        {ratings.map((rating, index) => {
-          const { x, y } = labelPosition(index, AXES.length, (rating.value / 99) * radius, center);
-          return <circle key={rating.axis} cx={x} cy={y} r={3.5} className="radar-vertex" />;
-        })}
+          {geo.vertices.map((v, i) => (
+            <circle
+              key={i}
+              cx={v.x}
+              cy={v.y}
+              r={active === i ? 4 : 3.5}
+              className="radar-vertex"
+              opacity={dimmed(i) ? 0.3 : 1}
+              style={{ transition: "r .2s ease, opacity .25s ease" }}
+            />
+          ))}
 
-        {AXES.map((axis, index) => {
-          const { x, y, anchor } = labelPosition(index, AXES.length, radius + 18, center);
-          return (
+          {geo.labels.map((l, i) => (
             <text
-              key={axis}
-              x={x}
-              y={y}
-              textAnchor={anchor}
+              key={i}
+              x={l.x}
+              y={l.y}
+              textAnchor="middle"
               dominantBaseline="middle"
               className="radar-label"
+              fill={active === i ? "var(--text)" : "var(--text-faint)"}
+              opacity={dimmed(i) ? 0.3 : 1}
+              style={{ transition: "fill .2s ease, opacity .25s ease" }}
             >
-              {t(`axis.${axis}` as MessageKey)}
+              {l.label}
             </text>
-          );
-        })}
-      </svg>
+          ))}
+
+          {AXES.map((_, i) => (
+            <polygon
+              key={i}
+              points={radarSector(geo.center, geo.radius + 17, i, AXES.length)}
+              fill="transparent"
+              className="radar-hitzone"
+              onMouseEnter={() => setActive(i)}
+              onMouseLeave={() => setActive(null)}
+              onClick={() => setActive((prev) => (prev === i ? null : i))}
+            />
+          ))}
+        </svg>
+
+        {active !== null && (
+          <div className="radar-tooltip">
+            <div className="radar-tooltip-label">{labels[active]}</div>
+            <div className="radar-tooltip-value">
+              {ratings[active].raw.toLocaleString(locale)}
+            </div>
+          </div>
+        )}
+      </div>
 
       <table className="visually-hidden">
         <caption>{t("radar.title")}</caption>

--- a/components/ui/SearchForm.tsx
+++ b/components/ui/SearchForm.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useRef, useState } from "react";
+import UserSearchInput, { type UserSearchInputHandle } from "./UserSearchInput";
 
 /**
  * Busca por usuário ou `owner/repo`. Aceita URL do GitHub colada inteira, porque
- * é o que a pessoa tem na mão quando chega aqui.
+ * é o que a pessoa tem na mão quando chega aqui. Usa UserSearchInput para
+ * sugestões de nome em tempo real.
  */
 export function SearchForm({
   placeholder,
@@ -16,23 +18,23 @@ export function SearchForm({
 }) {
   const router = useRouter();
   const [value, setValue] = useState("");
+  const inputRef = useRef<UserSearchInputHandle>(null);
 
   function submit(event: React.FormEvent) {
     event.preventDefault();
-    const target = normalize(value);
+    const resolved = inputRef.current?.resolve(value);
+    const target = resolved ?? normalize(value);
     if (target) router.push(`/${target}`);
   }
 
   return (
     <form className="search-form" onSubmit={submit}>
-      <input
-        type="text"
+      <UserSearchInput
+        ref={inputRef}
         value={value}
-        onChange={(event) => setValue(event.target.value)}
+        onValueChange={setValue}
+        label={placeholder}
         placeholder={placeholder}
-        aria-label={placeholder}
-        autoComplete="off"
-        spellCheck={false}
       />
       <button type="submit">{action}</button>
     </form>

--- a/components/ui/UserSearchInput.tsx
+++ b/components/ui/UserSearchInput.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { forwardRef, useEffect, useId, useImperativeHandle, useRef, useState } from "react";
+import type { UserSearchHit } from "@/lib/github/search";
+
+// Same grammar as lib/github/client.ts: alphanumerics + hyphens, 1–39 chars, at
+// least one alphanumeric. A username-shaped query skips the debounced search
+// (it's already a login); anything else is treated as a name and searched.
+const USERNAME_RE = /^(?=.*[a-z\d])[a-z\d-]{1,39}$/i;
+
+const AVATAR_FALLBACK =
+  "data:image/svg+xml;utf8," +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><rect width="64" height="64" fill="%23e8dfcd"/><circle cx="32" cy="26" r="12" fill="%23cfc4a8"/><rect x="14" y="44" width="36" height="28" rx="14" fill="%23cfc4a8"/></svg>',
+  );
+
+export interface UserSearchInputHandle {
+  /** Resolve a raw value to a login: usernames pass through as-is, real names
+   *  resolve via the last search round (first hit). Null when unresolvable —
+   *  the caller keeps the raw value and lets the route 404. */
+  resolve: (value: string) => string | null;
+}
+
+// Reusable "username or name" field with debounced by-name suggestions. Used by
+// the home scout form's sibling flows (compat picker) so name search works
+// everywhere. The field is controlled; suggestions resolve into `value` as the
+// chosen login.
+const UserSearchInput = forwardRef<UserSearchInputHandle, {
+  value: string;
+  onValueChange: (v: string) => void;
+  label: string;
+  placeholder: string;
+}>(function UserSearchInput({ value, onValueChange, label, placeholder }, ref) {
+  const [open, setOpen] = useState(false);
+  // Latest search round, tagged with the query it was run for. Render derives
+  // "show suggestions" from results.q === current query, so a keystroke that
+  // leaves the round stale never shows it — no sync clears needed.
+  const [results, setResults] = useState<{ q: string; hits: UserSearchHit[]; searching: boolean }>({
+    q: "",
+    hits: [],
+    searching: false,
+  });
+  const resultsRef = useRef(results);
+  resultsRef.current = results;
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const listboxId = useId();
+  const q = value.trim().replace(/^@/, "");
+  const matching = results.q === q && q.length >= 2 && !USERNAME_RE.test(q);
+
+  useImperativeHandle(ref, () => ({
+    resolve: (raw: string) => {
+      const v = raw.trim().replace(/^@/, "");
+      if (!v) return null;
+      if (USERNAME_RE.test(v)) return v;
+      const round = resultsRef.current;
+      return round.q === v && round.hits[0] ? round.hits[0].login : null;
+    },
+  }));
+
+  // Debounced by-name search: fires only while the input is focused and holds a
+  // non-username-shaped query.
+  useEffect(() => {
+    if (q.length < 2 || USERNAME_RE.test(q)) return;
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      setResults((prev) => ({ ...prev, searching: true }));
+      try {
+        const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
+        const data = (await res.json()) as { hits?: UserSearchHit[] };
+        if (!cancelled) setResults({ q, hits: data.hits ?? [], searching: false });
+      } catch {
+        if (!cancelled) setResults({ q, hits: [], searching: false });
+      }
+    }, 260);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [q]);
+
+  const showList = open && (results.searching || (matching && results.hits.length > 0));
+
+  return (
+    <div
+      ref={wrapRef}
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setOpen(false);
+      }}
+      className="search-input-wrap"
+    >
+      <span className="search-input-at">@</span>
+      <input
+        value={value}
+        onChange={(e) => {
+          onValueChange(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") setOpen(false);
+        }}
+        placeholder={placeholder}
+        autoComplete="off"
+        spellCheck={false}
+        role="combobox"
+        aria-expanded={showList}
+        aria-controls={listboxId}
+        aria-autocomplete="list"
+        aria-label={label}
+        className="search-input"
+      />
+      {showList && (
+        <ul
+          id={listboxId}
+          role="listbox"
+          className="search-dropdown"
+        >
+          {results.searching && results.hits.length === 0 && (
+            <li className="search-dropdown-status">
+              searching names…
+            </li>
+          )}
+          {results.hits.map((s) => (
+            <li key={s.login}>
+              <button
+                type="button"
+                role="option"
+                aria-selected
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  onValueChange(s.login);
+                  setOpen(false);
+                }}
+                className="search-dropdown-item"
+              >
+                <img
+                  src={s.avatarUrl ?? AVATAR_FALLBACK}
+                  alt=""
+                  aria-hidden
+                  onError={(e) => {
+                    e.currentTarget.onerror = null;
+                    e.currentTarget.src = AVATAR_FALLBACK;
+                  }}
+                  className="search-dropdown-avatar"
+                />
+                <span className="search-dropdown-text">
+                  <span className="search-dropdown-name">
+                    {s.name ?? s.login}
+                  </span>
+                  <span className="search-dropdown-login">
+                    @{s.login}
+                  </span>
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+});
+
+export default UserSearchInput;

--- a/components/ui/UserSearchInput.tsx
+++ b/components/ui/UserSearchInput.tsx
@@ -88,7 +88,6 @@ const UserSearchInput = forwardRef<UserSearchInputHandle, {
       }}
       className="search-input-wrap"
     >
-      <span className="search-input-at">@</span>
       <input
         value={value}
         onChange={(e) => {

--- a/lib/cards/index.ts
+++ b/lib/cards/index.ts
@@ -7,6 +7,7 @@ import {
   fetchUserRepos,
 } from "../github/client";
 import { GitmonError } from "../github/errors";
+import { checkCardRateLimit } from "../rateLimit";
 import { buildProfileCard } from "./profile";
 import { buildRepoCard } from "./repo";
 import { withSerial } from "./serial";
@@ -55,6 +56,12 @@ export async function getProfileCard(login: string): Promise<Card> {
     throw new GitmonError("not_found", `Login inválido: ${login}`, login);
   }
 
+  // Orçamento por IP antes do cache: toda busca de carta — cacheada ou não —
+  // conta contra a janela, protegendo o pool de tokens de scripts (ver
+  // lib/rateLimit.ts). Memoizado por requisição, então o generateMetadata e o
+  // render da mesma página compartilham UMA checagem.
+  await checkCardRateLimit();
+
   const card = await cached(
     `card:${CARD_VERSION}:profile:${login.toLowerCase()}`,
     CARD_DATA_TTL_SECONDS,
@@ -77,6 +84,8 @@ export async function getRepoCard(owner: string, name: string): Promise<Card> {
   if (!isValidLogin(owner) || !isValidRepoName(name)) {
     throw new GitmonError("not_found", `Repositório inválido: ${owner}/${name}`);
   }
+
+  await checkCardRateLimit();
 
   const card = await cached(
     `card:${CARD_VERSION}:repo:${owner.toLowerCase()}/${name.toLowerCase()}`,
@@ -110,6 +119,8 @@ export async function getProfileRepos(
   limit = 12,
 ): Promise<RepoSummary[]> {
   if (!isValidLogin(login)) return [];
+
+  await checkCardRateLimit();
 
   return cached(
     `repos:${CARD_VERSION}:${login.toLowerCase()}:${limit}`,

--- a/lib/cards/ratings.ts
+++ b/lib/cards/ratings.ts
@@ -91,8 +91,7 @@ export function ratingsFor(input: RatingInput): AxisRating[] {
 /**
  * Pontos do polígono no espaço do SVG.
  *
- * Ângulo inicial em -90° para o primeiro eixo apontar para cima: um polígono
- * apoiado num vértice superior lê como emblema; rotacionado, lê como erro.
+ * Wrapper que normaliza AxisRating[] e delega para lib/radar.ts.
  */
 export function polygonPoints(
   ratings: AxisRating[],

--- a/lib/github/client.ts
+++ b/lib/github/client.ts
@@ -1,20 +1,34 @@
 import { GitmonError } from "./errors";
+import {
+  benchToken,
+  pickFailover,
+  pickToken,
+  recordTokenHealth,
+  tokenPool,
+} from "./tokens";
+import type { PoolToken } from "./tokens";
 import type { GitHubContributor, GitHubRepo, GitHubUser } from "./types";
 
 const API = "https://api.github.com";
 
 /**
- * Token de app no servidor (RFC 5). O visitante nunca faz login — é isso que
- * mantém a fricção zero que faz a fórmula funcionar.
+ * Pool de tokens no servidor (RFC 5). O visitante nunca faz login — é isso que
+ * mantém a fricção zero que faz a fórmula funcionar. Cada login é preso a um
+ * token por hash (ver `tokens.ts`); se esse token estiver limitado, tenta um
+ * failover único para o token mais saudável antes de desistir.
  */
-function authHeaders(): HeadersInit {
-  const token = process.env.GITHUB_TOKEN?.trim();
-  if (!token) {
+function discoverPool(): PoolToken[] {
+  const pool = tokenPool();
+  if (!pool.length) {
     throw new GitmonError(
       "no_token",
-      "GITHUB_TOKEN não configurado. Sem token o limite é 60 req/h por IP.",
+      "Nenhum token GitHub configurado. Configure GITHUB_TOKEN (ou GITHUB_TOKENS) — sem token o limite é 60 req/h por IP.",
     );
   }
+  return pool;
+}
+
+function authHeaders(token: string): HeadersInit {
   return {
     Authorization: `Bearer ${token}`,
     Accept: "application/vnd.github+json",
@@ -23,47 +37,70 @@ function authHeaders(): HeadersInit {
   };
 }
 
-async function request<T>(path: string): Promise<T> {
-  let response: Response;
-  try {
-    response = await fetch(`${API}${path}`, {
-      headers: authHeaders(),
-      // O cache é nosso, no Redis. Não queremos duas camadas discordando.
-      cache: "no-store",
-    });
-  } catch (cause) {
-    throw new GitmonError("upstream", "Falha de rede ao consultar a API do GitHub.", String(cause));
-  }
+async function request<T>(path: string, login: string): Promise<T> {
+  const pool = discoverPool();
+  let current = pickToken(login, pool);
 
-  if (response.ok) {
-    return (await response.json()) as T;
-  }
+  for (let attempt = 0; attempt <= 1; attempt++) {
+    let response: Response;
+    try {
+      response = await fetch(`${API}${path}`, {
+        headers: authHeaders(current!.token),
+        // O cache é nosso, no Redis. Não queremos duas camadas discordando.
+        cache: "no-store",
+      });
+    } catch (cause) {
+      throw new GitmonError(
+        "upstream",
+        "Falha de rede ao consultar a API do GitHub.",
+        String(cause),
+      );
+    }
 
-  if (response.status === 404) {
-    throw new GitmonError("not_found", `Recurso não encontrado: ${path}`);
-  }
+    // Fire-and-forget: grava a saúde do token que acabou de responder.
+    void recordTokenHealth(current!.idx, response.headers);
 
-  // 403 com o contador zerado é rate limit; 403 com contador sobrando é outra
-  // coisa (abuso, token sem escopo) e não deve ser reportado como rate limit.
-  const remaining = response.headers.get("x-ratelimit-remaining");
-  if ((response.status === 403 || response.status === 429) && remaining === "0") {
-    const reset = response.headers.get("x-ratelimit-reset");
+    if (response.ok) {
+      return (await response.json()) as T;
+    }
+
+    if (response.status === 404) {
+      throw new GitmonError("not_found", `Recurso não encontrado: ${path}`);
+    }
+
+    // 403 com o contador zerado é rate limit; 403 com contador sobrando é outra
+    // coisa (abuso, token sem escopo) e não deve ser reportado como rate limit.
+    const remaining = response.headers.get("x-ratelimit-remaining");
+    if ((response.status === 403 || response.status === 429) && remaining === "0") {
+      // Põe o token atual de castigo e tenta um failover único. Na segunda
+      // tentativa sem failover, propagamos o erro de rate limit de verdade.
+      void benchToken(current!.idx, response.headers);
+      if (attempt === 0) {
+        const fallback = await pickFailover(current!.idx, pool);
+        if (fallback) {
+          current = fallback;
+          continue;
+        }
+      }
+      throw new GitmonError(
+        "rate_limit",
+        "Limite de requisições da API do GitHub atingido.",
+        response.headers.get("x-ratelimit-reset") ?? undefined,
+      );
+    }
+
     throw new GitmonError(
-      "rate_limit",
-      "Limite de requisições da API do GitHub atingido.",
-      reset ?? undefined,
+      "upstream",
+      `API do GitHub respondeu ${response.status}.`,
+      await response.text().catch(() => undefined),
     );
   }
 
-  throw new GitmonError(
-    "upstream",
-    `API do GitHub respondeu ${response.status}.`,
-    await response.text().catch(() => undefined),
-  );
+  throw new GitmonError("upstream", "Falha ao consultar a API do GitHub.");
 }
 
 export async function fetchUser(login: string): Promise<GitHubUser> {
-  return request<GitHubUser>(`/users/${encodeURIComponent(login)}`);
+  return request<GitHubUser>(`/users/${encodeURIComponent(login)}`, login);
 }
 
 /**
@@ -74,12 +111,14 @@ export async function fetchUser(login: string): Promise<GitHubUser> {
 export async function fetchUserRepos(login: string): Promise<GitHubRepo[]> {
   return request<GitHubRepo[]>(
     `/users/${encodeURIComponent(login)}/repos?per_page=100&sort=updated&type=owner`,
+    login,
   );
 }
 
 export async function fetchRepo(owner: string, repo: string): Promise<GitHubRepo> {
   return request<GitHubRepo>(
     `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
+    owner,
   );
 }
 
@@ -97,6 +136,7 @@ export async function fetchRepoContributors(
   try {
     const contributors = await request<GitHubContributor[]>(
       `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contributors?per_page=10`,
+      owner,
     );
     return Array.isArray(contributors) ? contributors : [];
   } catch {

--- a/lib/github/oauth.ts
+++ b/lib/github/oauth.ts
@@ -1,14 +1,14 @@
-import { baseUrl } from "../config";
+import "server-only";
 
-// Fluxo mínimo de OAuth do GitHub — "gere sua própria carta em um clique". O
-// visitante cai em /api/auth/login, é levado ao GitHub e volta para /<seu login>,
-// onde a carta já é gerada. Nenhuma sessão é mantida: o token do OAuth é trocado,
-// usado uma vez para ler o login e descartado.
+// Minimal GitHub OAuth App flow — "match your own profile in one click". A
+// visitor hits /api/auth/login, gets bounced to GitHub, and lands back on
+// /<their login> where the scout already ran. No session is kept: the OAuth
+// token is exchanged, used once to read the login, then discarded.
 //
-// Configure um OAuth App do GitHub (github.com/settings/developers) com a URL de
-// callback <seu-origin>/api/auth/callback. Tudo degrada limpo: sem
-// GITHUB_OAUTH_CLIENT_ID/GITHUB_OAUTH_CLIENT_SECRET o botão de login simplesmente
-// não aparece.
+// Configure a GitHub OAuth App (github.com/settings/developers) with the
+// callback URL <your-origin>/api/auth/callback. Everything degrades cleanly:
+// without GITHUB_OAUTH_CLIENT_ID/GITHUB_OAUTH_CLIENT_SECRET the login button
+// simply doesn't render.
 
 interface OAuthConfig {
   clientId: string;
@@ -19,12 +19,12 @@ export function oauthConfig(): OAuthConfig | null {
   const clientId = process.env.GITHUB_OAUTH_CLIENT_ID?.trim();
   const clientSecret = process.env.GITHUB_OAUTH_CLIENT_SECRET?.trim();
   if (!clientId || !clientSecret) return null;
-  // Segredos de OAuth App do GitHub são sempre 40 hex em minúsculas; um client ID
-  // nunca é. Pega o clássico erro de copiar client_id/client_secret trocados, que
-  // senão só aparece como falha confusa na hora do authorize.
+  // GitHub OAuth App client secrets are always 40 lowercase hex chars; a client
+  // ID never is. Catches the classic client_id/client_secret copy-paste swap,
+  // which would otherwise only surface as a confusing failure at authorize time.
   if (/^[0-9a-f]{40}$/.test(clientId)) {
     console.warn(
-      "[oauth] GITHUB_OAUTH_CLIENT_ID parece um client secret (40 hex). Verifique as variáveis.",
+      "[oauth] GITHUB_OAUTH_CLIENT_ID looks like a client secret (40-hex). Check the env vars.",
     );
     return null;
   }
@@ -35,18 +35,22 @@ export function oauthEnabled(): boolean {
   return oauthConfig() !== null;
 }
 
-/**
- * A origem usada no redirect_uri do OAuth. Vem do `lib/config.ts` — a RFC 11
- * proíbe hardcodar domínio; o override explícito e as URLs de deploy da Vercel
- * já são resolvidos lá.
- */
-function appBaseUrl(): string {
-  return baseUrl();
+// The origin used to build the OAuth redirect_uri. Explicit override wins;
+// VERCEL_URL covers Vercel deploys (preview + production); localhost as a last
+// resort for local dev.
+export function appBaseUrl(): string {
+  const explicit = process.env.NEXT_PUBLIC_APP_URL?.trim();
+  if (explicit) return explicit.replace(/\/+$/, "");
+  const prod = process.env.VERCEL_PROJECT_PRODUCTION_URL?.trim();
+  if (prod) return `https://${prod}`;
+  const url = process.env.VERCEL_URL?.trim();
+  if (url) return `https://${url}`;
+  return "http://localhost:3000";
 }
 
 export function oauthAuthorizeUrl(state: string): string {
   const config = oauthConfig();
-  if (!config) throw new Error("OAuth não configurado.");
+  if (!config) throw new Error("OAuth is not configured.");
   const params = new URLSearchParams({
     client_id: config.clientId,
     scope: "read:user",
@@ -58,7 +62,7 @@ export function oauthAuthorizeUrl(state: string): string {
 
 export async function exchangeOauthCode(code: string): Promise<string> {
   const config = oauthConfig();
-  if (!config) throw new Error("OAuth não configurado.");
+  if (!config) throw new Error("OAuth is not configured.");
   const res = await fetch("https://github.com/login/oauth/access_token", {
     method: "POST",
     headers: { Accept: "application/json", "Content-Type": "application/json" },
@@ -68,13 +72,13 @@ export async function exchangeOauthCode(code: string): Promise<string> {
       code,
     }),
   });
-  if (!res.ok) throw new Error("O GitHub rejeitou o código OAuth.");
+  if (!res.ok) throw new Error("GitHub rejected the OAuth code.");
   const body = (await res.json()) as {
     access_token?: string;
     error_description?: string;
   };
   if (!body.access_token)
-    throw new Error(body.error_description ?? "Troca do código OAuth falhou.");
+    throw new Error(body.error_description ?? "OAuth exchange failed.");
   return body.access_token;
 }
 
@@ -95,7 +99,7 @@ export async function fetchOauthUser(token: string): Promise<OAuthUser> {
   if (!res.ok) {
     const snippet = (await res.text().catch(() => "")).slice(0, 160);
     throw new Error(
-      `O GitHub não devolveu o usuário logado (HTTP ${res.status}): ${snippet}`,
+      `GitHub didn't return the logged-in user (HTTP ${res.status}): ${snippet}`,
     );
   }
   const body = (await res.json()) as {
@@ -103,7 +107,7 @@ export async function fetchOauthUser(token: string): Promise<OAuthUser> {
     name?: string | null;
     avatar_url?: string;
   };
-  if (!body.login) throw new Error("O GitHub não devolveu um login.");
+  if (!body.login) throw new Error("GitHub didn't return a login.");
   return {
     login: body.login,
     name: body.name ?? null,

--- a/lib/github/oauth.ts
+++ b/lib/github/oauth.ts
@@ -1,0 +1,112 @@
+import { baseUrl } from "../config";
+
+// Fluxo mínimo de OAuth do GitHub — "gere sua própria carta em um clique". O
+// visitante cai em /api/auth/login, é levado ao GitHub e volta para /<seu login>,
+// onde a carta já é gerada. Nenhuma sessão é mantida: o token do OAuth é trocado,
+// usado uma vez para ler o login e descartado.
+//
+// Configure um OAuth App do GitHub (github.com/settings/developers) com a URL de
+// callback <seu-origin>/api/auth/callback. Tudo degrada limpo: sem
+// GITHUB_OAUTH_CLIENT_ID/GITHUB_OAUTH_CLIENT_SECRET o botão de login simplesmente
+// não aparece.
+
+interface OAuthConfig {
+  clientId: string;
+  clientSecret: string;
+}
+
+export function oauthConfig(): OAuthConfig | null {
+  const clientId = process.env.GITHUB_OAUTH_CLIENT_ID?.trim();
+  const clientSecret = process.env.GITHUB_OAUTH_CLIENT_SECRET?.trim();
+  if (!clientId || !clientSecret) return null;
+  // Segredos de OAuth App do GitHub são sempre 40 hex em minúsculas; um client ID
+  // nunca é. Pega o clássico erro de copiar client_id/client_secret trocados, que
+  // senão só aparece como falha confusa na hora do authorize.
+  if (/^[0-9a-f]{40}$/.test(clientId)) {
+    console.warn(
+      "[oauth] GITHUB_OAUTH_CLIENT_ID parece um client secret (40 hex). Verifique as variáveis.",
+    );
+    return null;
+  }
+  return { clientId, clientSecret };
+}
+
+export function oauthEnabled(): boolean {
+  return oauthConfig() !== null;
+}
+
+/**
+ * A origem usada no redirect_uri do OAuth. Vem do `lib/config.ts` — a RFC 11
+ * proíbe hardcodar domínio; o override explícito e as URLs de deploy da Vercel
+ * já são resolvidos lá.
+ */
+function appBaseUrl(): string {
+  return baseUrl();
+}
+
+export function oauthAuthorizeUrl(state: string): string {
+  const config = oauthConfig();
+  if (!config) throw new Error("OAuth não configurado.");
+  const params = new URLSearchParams({
+    client_id: config.clientId,
+    scope: "read:user",
+    state,
+    redirect_uri: `${appBaseUrl()}/api/auth/callback`,
+  });
+  return `https://github.com/login/oauth/authorize?${params.toString()}`;
+}
+
+export async function exchangeOauthCode(code: string): Promise<string> {
+  const config = oauthConfig();
+  if (!config) throw new Error("OAuth não configurado.");
+  const res = await fetch("https://github.com/login/oauth/access_token", {
+    method: "POST",
+    headers: { Accept: "application/json", "Content-Type": "application/json" },
+    body: JSON.stringify({
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      code,
+    }),
+  });
+  if (!res.ok) throw new Error("O GitHub rejeitou o código OAuth.");
+  const body = (await res.json()) as {
+    access_token?: string;
+    error_description?: string;
+  };
+  if (!body.access_token)
+    throw new Error(body.error_description ?? "Troca do código OAuth falhou.");
+  return body.access_token;
+}
+
+export interface OAuthUser {
+  login: string;
+  name: string | null;
+  avatarUrl: string;
+}
+
+export async function fetchOauthUser(token: string): Promise<OAuthUser> {
+  const res = await fetch("https://api.github.com/user", {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!res.ok) {
+    const snippet = (await res.text().catch(() => "")).slice(0, 160);
+    throw new Error(
+      `O GitHub não devolveu o usuário logado (HTTP ${res.status}): ${snippet}`,
+    );
+  }
+  const body = (await res.json()) as {
+    login?: string;
+    name?: string | null;
+    avatar_url?: string;
+  };
+  if (!body.login) throw new Error("O GitHub não devolveu um login.");
+  return {
+    login: body.login,
+    name: body.name ?? null,
+    avatarUrl: body.avatar_url ?? "",
+  };
+}

--- a/lib/github/search.ts
+++ b/lib/github/search.ts
@@ -1,0 +1,75 @@
+import "server-only";
+import { tokenPool } from "./tokens";
+
+// GitHub user search (REST /search/users) — powers the home page's "search by
+// name" suggestions, so a visitor can find a profile without knowing a username.
+// Sits on the same token pool as the GraphQL scout, but search has its OWN rate
+// limit (30 req/min per token), so it can't eat into the GraphQL budget. No
+// token = no suggestions (typing + submit still works, as before).
+// Results are memoized in-memory for 10 minutes: as-you-type queries repeat a
+// lot, and every cache hit is a request saved on the search quota.
+
+export interface UserSearchHit {
+  login: string;
+  name: string | null;
+  avatarUrl: string | null;
+}
+
+const SEARCH_URL = "https://api.github.com/search/users";
+const REQUEST_TIMEOUT_MS = 8_000;
+const CACHE_TTL_MS = 10 * 60 * 1000;
+const CACHE_MAX = 200;
+const MAX_HITS = 6;
+
+const cache = new Map<string, { at: number; hits: UserSearchHit[] }>();
+
+function pruneCache(now: number): void {
+  if (cache.size <= CACHE_MAX) return;
+  for (const [k, v] of cache) if (now - v.at > CACHE_TTL_MS) cache.delete(k);
+}
+
+// Best-effort by design: any failure (network, rate limit, malformed body)
+// degrades to "no suggestions" — search is a nicety, never a blocker.
+export async function searchUsers(rawQuery: string): Promise<UserSearchHit[]> {
+  const q = rawQuery.trim();
+  if (q.length < 2) return [];
+  const key = q.toLowerCase();
+
+  const memo = cache.get(key);
+  if (memo && Date.now() - memo.at <= CACHE_TTL_MS) return memo.hits;
+  pruneCache(Date.now());
+
+  const pool = tokenPool();
+  if (!pool.length) return [];
+
+  // type:user keeps orgs out — only people have a scoutable GraphQL `user`.
+  const url = `${SEARCH_URL}?q=${encodeURIComponent(`${q} type:user`)}&per_page=${MAX_HITS}`;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${pool[0].token}`,
+        Accept: "application/vnd.github+json",
+      },
+      signal: ctrl.signal,
+    });
+    if (!res.ok) return []; // 403/422 (search quota) or 5xx — no suggestions
+    const body = (await res.json()) as {
+      items?: { login?: string; name?: string | null; avatar_url?: string | null }[];
+    };
+    const hits = (body.items ?? [])
+      .filter((i) => typeof i.login === "string" && i.login.length > 0)
+      .map((i) => ({
+        login: i.login as string,
+        name: i.name ?? null,
+        avatarUrl: i.avatar_url ?? null,
+      }));
+    cache.set(key, { at: Date.now(), hits });
+    return hits;
+  } catch {
+    return []; // network / timeout — same graceful degradation
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/lib/github/tokens.ts
+++ b/lib/github/tokens.ts
@@ -1,0 +1,152 @@
+// Pool de tokens do GitHub. O limite da API REST (~5.000 req/h) é por *conta*,
+// então `GITHUB_TOKENS` aceita tokens de contas distintas e multiplica o teto
+// (4 tokens ≈ 20k req/h). A seleção é um hash sem estado do login — cada
+// instância serverless (ou worker) calcula a mesma escolha sem coordenação,
+// distribui usuários distintos de forma uniforme e prende um login a um token,
+// o que compõe com o single-flight de `lib/cards/index.ts`.
+//
+// O Redis entra só no caminho infeliz: os headers de rate limit de cada resposta
+// são gravados por token (fire-and-forget), e quando o token do chamador é
+// limitado, `pickFailover` escolhe o token mais saudável dos outros. Mesma
+// postura de `lib/cache/redis.ts` — o Redis é consultivo e best-effort, nunca
+// bloqueia nem derruba o caminho quente. Sem dado de saúde, o token é tratado
+// como saudável.
+
+import { getRedisClient } from "../cache/redis";
+
+export interface PoolToken {
+  token: string;
+  idx: number;
+}
+
+interface TokenHealth {
+  remaining: number; // pontos restantes desta janela (x-ratelimit-remaining)
+  reset: number; // timestamp unix em que a janela recarrega (x-ratelimit-reset)
+}
+
+const HEALTH_VERSION = "v1";
+const keyFor = (idx: number) => `gitmon:ghtoken:${HEALTH_VERSION}:${idx}`;
+// A janela dura no máximo ~65 min (60 + drift); saúde velha expira em "desconhecido".
+const HEALTH_TTL_SECONDS = 65 * 60;
+// Abaixo disto o token é poupado até o reset — folga o bastante para que scouts
+// em voo (alguns pontos cada) não estourem o zero no meio.
+const BENCH_REMAINING = 200;
+// Bench de segurança quando a resposta limitada não traz reset/Retry-After útil.
+const BENCH_FALLBACK_SECONDS = 120;
+
+// `GITHUB_TOKENS` (separado por vírgula, contas distintas) vence; `GITHUB_TOKEN`
+// sozinho continua funcionando como um pool de um, então deploys existentes se
+// comportam exatamente como antes.
+export function tokenPool(): PoolToken[] {
+  const multi = process.env.GITHUB_TOKENS;
+  if (multi) {
+    const tokens = multi
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    if (tokens.length) return tokens.map((token, idx) => ({ token, idx }));
+  }
+  const single = process.env.GITHUB_TOKEN;
+  return single ? [{ token: single, idx: 0 }] : [];
+}
+
+// FNV-1a: pequeno, estável e bem distribuído para strings curtas. Em minúsculas
+// para que a caixa ignorada pelo GitHub não espalhe o mesmo usuário por tokens.
+export function hashLogin(login: string): number {
+  const s = login.toLowerCase();
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+export function pickToken(login: string, pool = tokenPool()): PoolToken | null {
+  if (!pool.length) return null;
+  return pool[hashLogin(login) % pool.length];
+}
+
+// Grava os headers de rate limit de um token após uma resposta do GitHub.
+// Fire-and-forget: o chamador nunca espera, e perder uma amostra não faz mal —
+// a próxima resposta sobrescreve.
+export async function recordTokenHealth(idx: number, headers: Headers): Promise<void> {
+  const remaining = headers.get("x-ratelimit-remaining");
+  const reset = headers.get("x-ratelimit-reset");
+  if (remaining === null || reset === null) return;
+  const health: TokenHealth = { remaining: Number(remaining), reset: Number(reset) };
+  if (!Number.isFinite(health.remaining) || !Number.isFinite(health.reset)) return;
+  const redis = await getRedisClient();
+  if (!redis) return;
+  try {
+    await redis.set(keyFor(idx), JSON.stringify(health), "EX", HEALTH_TTL_SECONDS);
+  } catch (e) {
+    console.error("[tokens] health write failed:", (e as Error).message);
+  }
+}
+
+// Põe um token de castigo por rate limit (403/429), até o mais tardar entre o
+// reset da janela e qualquer Retry-After (limites secundários/abuso mandam
+// Retry-After enquanto a janela horária ainda tem pontos). Fire-and-forget.
+export async function benchToken(idx: number, headers: Headers): Promise<void> {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const retryAfter = Number(headers.get("retry-after") ?? NaN);
+  const reset = Number(headers.get("x-ratelimit-reset") ?? NaN);
+  const until = Math.max(
+    Number.isFinite(retryAfter) ? nowSec + retryAfter : 0,
+    Number.isFinite(reset) ? reset : 0,
+    nowSec + BENCH_FALLBACK_SECONDS,
+  );
+  const redis = await getRedisClient();
+  if (!redis) return;
+  try {
+    await redis.set(
+      keyFor(idx),
+      JSON.stringify({ remaining: 0, reset: until } satisfies TokenHealth),
+      "EX",
+      HEALTH_TTL_SECONDS,
+    );
+  } catch (e) {
+    console.error("[tokens] bench write failed:", (e as Error).message);
+  }
+}
+
+// O token mais saudável que não seja `excludeIdx`: maior remaining conhecido,
+// com saúde desconhecida/vencida tratada como janela nova (quota completa).
+// Tokens de castigo (abaixo da folga, reset ainda à frente) são pulados; se
+// todos os outros estiverem de castigo, devolve null e o chamador propaga o
+// erro de rate limit. Redis fora do ar/ilegível degrada para "primeiro outro
+// token", em vez de falhar.
+export async function pickFailover(
+  excludeIdx: number,
+  pool = tokenPool(),
+): Promise<PoolToken | null> {
+  const candidates = pool.filter((t) => t.idx !== excludeIdx);
+  if (!candidates.length) return null;
+
+  const redis = await getRedisClient();
+  if (!redis) return candidates[0];
+
+  try {
+    const raws = await Promise.all(candidates.map((t) => redis.get(keyFor(t.idx))));
+    const nowSec = Math.floor(Date.now() / 1000);
+    let best: PoolToken | null = null;
+    let bestRemaining = -1;
+    for (let i = 0; i < candidates.length; i++) {
+      let remaining = Infinity; // sem dado → assume saudável
+      if (raws[i]) {
+        const h = JSON.parse(raws[i] as string) as TokenHealth;
+        remaining = nowSec >= h.reset ? Infinity : h.remaining; // passou do reset → recarregou
+      }
+      if (remaining < BENCH_REMAINING) continue; // de castigo
+      if (remaining > bestRemaining) {
+        best = candidates[i];
+        bestRemaining = remaining;
+      }
+    }
+    return best;
+  } catch (e) {
+    console.error("[tokens] failover read failed:", (e as Error).message);
+    return candidates[0];
+  }
+}

--- a/lib/i18n/dictionaries.ts
+++ b/lib/i18n/dictionaries.ts
@@ -82,6 +82,7 @@ const pt = {
   "error.no_token": "Servidor sem token do GitHub configurado.",
   "error.upstream": "A API do GitHub não respondeu.",
   "error.battle_expired": "Este resultado de batalha expirou. Gere uma nova batalha.",
+  "error.retry": "Tentar de novo",
 
   "home.tagline": "Cartas geradas a partir de dados reais do GitHub.",
   "home.description":
@@ -233,6 +234,7 @@ const en: Record<MessageKey, string> = {
   "error.no_token": "Server has no GitHub token configured.",
   "error.upstream": "The GitHub API did not respond.",
   "error.battle_expired": "This battle result has expired. Run a new battle.",
+  "error.retry": "Try again",
 
   "home.tagline": "Cards generated from real GitHub data.",
   "home.description": "One image URL, no login, updating on its own. Paste it in your README.",

--- a/lib/i18n/dictionaries.ts
+++ b/lib/i18n/dictionaries.ts
@@ -86,6 +86,7 @@ const pt = {
   "home.tagline": "Cartas geradas a partir de dados reais do GitHub.",
   "home.description":
     "Uma URL de imagem, sem login, que se atualiza sozinha. Cole no seu README.",
+  "search.scouting": "buscando nomes…",
   "home.search": "Buscar usuário ou owner/repositório",
   "home.searchAction": "Gerar carta",
   "home.samples": "Exemplos",
@@ -235,6 +236,7 @@ const en: Record<MessageKey, string> = {
 
   "home.tagline": "Cards generated from real GitHub data.",
   "home.description": "One image URL, no login, updating on its own. Paste it in your README.",
+  "search.scouting": "searching names…",
   "home.search": "Search a user or owner/repository",
   "home.searchAction": "Generate card",
   "home.samples": "Samples",

--- a/lib/i18n/dictionaries.ts
+++ b/lib/i18n/dictionaries.ts
@@ -177,6 +177,8 @@ const pt = {
   "battle.share": "Compartilhar resultado",
   "battle.rematch": "Batalhar de novo",
   "battle.skip": "Pular animação",
+  "battle.radar": "Assinatura do perfil",
+  "battle.radarCaption": "Sobreposição dos dois oponentes",
 } as const;
 
 export type MessageKey = keyof typeof pt;
@@ -324,6 +326,8 @@ const en: Record<MessageKey, string> = {
   "battle.share": "Share result",
   "battle.rematch": "Battle again",
   "battle.skip": "Skip animation",
+  "battle.radar": "Profile signature",
+  "battle.radarCaption": "Both opponents overlaid",
 };
 
 const DICTIONARIES: Record<Locale, Record<MessageKey, string>> = { pt, en };

--- a/lib/radar.ts
+++ b/lib/radar.ts
@@ -1,0 +1,110 @@
+/**
+ * Geometria compartilhada do radar.
+ *
+ * Extraída de `lib/cards/ratings.ts` para servir tanto o RadarChart do perfil
+ * quanto visualizações de batalha. Funções puras de geometria SVG — sem
+ * dependência de React, i18n ou dados de perfil.
+ *
+ * O polígono começa em -90° (primeiro eixo aponta para cima) para ler como
+ * emblema; rotacionado, lê como erro.
+ */
+
+export interface RadarVertex {
+  x: number;
+  y: number;
+}
+
+export interface RadarLabel extends RadarVertex {
+  label: string;
+}
+
+export interface RadarGeometry {
+  center: number;
+  radius: number;
+  /** Corners of the data polygon, one per axis. */
+  vertices: RadarVertex[];
+  /** SVG `points` attribute for the data polygon. */
+  points: string;
+  /** Concentric polygon outlines at the given fractions of the radius. */
+  rings: string[];
+  /** One polygon wedge per axis: centre → edge-mid → vertex → edge-mid. */
+  sectors: string[];
+  /** One label per axis, anchored just outside the outer ring. */
+  labels: RadarLabel[];
+}
+
+const RING_FRACTIONS = [1 / 3, 2 / 3, 1];
+const RADIUS_SHARE = 0.72;
+const LABEL_GAP_SHARE = 0.1;
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/** Angle for axis `i`, starting at -90° (top) and going clockwise. */
+function angleFor(i: number, sides: number): number {
+  return ((-90 + (i * 360) / sides) * Math.PI) / 180;
+}
+
+function at(center: number, radius: number, i: number, sides: number): RadarVertex {
+  const angle = angleFor(i, sides);
+  return {
+    x: round2(center + radius * Math.cos(angle)),
+    y: round2(center + radius * Math.sin(angle)),
+  };
+}
+
+/** SVG `points` for a regular polygon with `sides` sides at the given radius. */
+export function polygonPoints(sides: number, radius: number, center: number): string {
+  return Array.from({ length: sides }, (_, i) => {
+    const { x, y } = at(center, radius, i, sides);
+    return `${x},${y}`;
+  }).join(" ");
+}
+
+/** One wedge of the polygon: centre → edge midpoint → vertex → edge midpoint. */
+export function radarSector(center: number, radius: number, axis: number, sides: number): string {
+  const theta = angleFor(axis, sides);
+  const mid = radius * Math.cos(Math.PI / sides);
+  const pt = (r: number, a: number) =>
+    `${round2(center + r * Math.cos(a))},${round2(center + r * Math.sin(a))}`;
+  return [
+    `${center},${center}`,
+    pt(mid, theta - Math.PI / sides),
+    pt(radius, theta),
+    pt(mid, theta + Math.PI / sides),
+  ].join(" ");
+}
+
+/**
+ * Full radar geometry for a set of normalized values (0–99).
+ *
+ * `values` must be in axis order. The number of elements determines the
+ * polygon's side count — works for 5 (profile) or any other number.
+ */
+export function radarGeometry(
+  values: number[],
+  labels: string[],
+  size: number,
+): RadarGeometry {
+  const sides = values.length;
+  const center = size / 2;
+  const radius = center * RADIUS_SHARE;
+
+  const vertices = values.map((v, i) =>
+    at(center, (radius * Math.min(Math.max(v, 0), 99)) / 99, i, sides),
+  );
+
+  return {
+    center,
+    radius,
+    vertices,
+    points: vertices.map((v) => `${v.x},${v.y}`).join(" "),
+    rings: RING_FRACTIONS.map((f) => polygonPoints(sides, radius * f, center)),
+    sectors: Array.from({ length: sides }, (_, i) => radarSector(center, radius, i, sides)),
+    labels: labels.map((label, i) => ({
+      label,
+      ...at(center, radius + size * LABEL_GAP_SHARE, i, sides),
+    })),
+  };
+}

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -20,9 +20,18 @@ export interface RateLimitDecision {
   retryAfterSeconds: number;
 }
 
-export const ALLOWED_PER_WINDOW = 20;
-export const WINDOW_SECONDS = 10 * 60;
+// Defaults: 20 buscas por IP a cada 10 min. Tuning por env para produção ajustar
+// sem tocar em código — e o valor default continua o mesmo de sempre.
+export const ALLOWED_PER_WINDOW = readLimit("CARD_RATE_LIMIT_PER_WINDOW", 20);
+export const WINDOW_SECONDS = readLimit("CARD_RATE_LIMIT_WINDOW_SECONDS", 10 * 60);
 const KEY_PREFIX = "gitmon:rl:";
+
+function readLimit(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 // O Vercel entrega o IP real em x-forwarded-for (primeiro hop) / x-real-ip; o que
 // estiver à frente pode prefixar seus próprios hops, então só o primeiro valor é
@@ -76,6 +85,10 @@ async function allowFromRedis(redis: Redis, ip: string): Promise<RateLimitDecisi
 // compartilham UMA checagem (e um incremento) — o mesmo padrão de single-flight
 // do loadProfile. Lança GitmonError("rate_limit") quando bloqueado.
 export const checkCardRateLimit = cache(async (): Promise<void> => {
+  // Em dev a única "ameaça" é o próprio desenvolvedor recarregando a carta —
+  // puni-lo com o orçamento anti-scraper é sabotar o fluxo que a janela existe
+  // para proteger. Produção continua bloqueando IP (ver lib/rateLimit.ts).
+  if (process.env.NODE_ENV === "development") return;
   let ip = "unknown";
   try {
     ip = clientIp(await headers());

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -1,0 +1,109 @@
+import { cache } from "react";
+import { headers } from "next/headers";
+import type Redis from "ioredis";
+import { getRedisClient } from "./cache/redis";
+import { GitmonError } from "./github/errors";
+
+// Orçamento de buscas por IP, protegendo o pool de tokens do GitHub de scripts e
+// scrapers. Aplicado na camada de dados, ANTES do cache/fetch, então toda busca
+// de carta — cacheada ou não — conta contra a janela.
+//
+// Limites por IP, janela fixa (INCR + EXPIRE). Best-effort, espelhando
+// lib/cache/redis.ts: sem Redis (ou com Redis com soluço), a mesma janela é
+// garantida por um contador em memória (por instância — suficiente em dev e uma
+// degradação graciosa em produção). Nada aqui lança em cima de infra; quo o
+// limite estourou, lança GitmonError("rate_limit"), que as rotas já sabem
+// renderizar (i18n + status 429).
+
+export interface RateLimitDecision {
+  allowed: boolean;
+  retryAfterSeconds: number;
+}
+
+export const ALLOWED_PER_WINDOW = 20;
+export const WINDOW_SECONDS = 10 * 60;
+const KEY_PREFIX = "gitmon:rl:";
+
+// O Vercel entrega o IP real em x-forwarded-for (primeiro hop) / x-real-ip; o que
+// estiver à frente pode prefixar seus próprios hops, então só o primeiro valor é
+// confiável.
+export function clientIp(h: Headers): string {
+  const fwd = h.get("x-forwarded-for");
+  if (fwd) {
+    const first = fwd.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  const real = h.get("x-real-ip");
+  if (real) {
+    const t = real.trim();
+    if (t) return t;
+  }
+  return "unknown";
+}
+
+// Janela em memória (uma por instância). Limitada: quando passa do limiar, os
+// buckets expirados são podados antes de admitir novos.
+const memory = new Map<string, { count: number; resetAt: number }>();
+
+export function allowFromMemory(ip: string): RateLimitDecision {
+  const now = Date.now();
+  if (memory.size > 1000) {
+    for (const [k, v] of memory) if (v.resetAt <= now) memory.delete(k);
+  }
+  let rec = memory.get(ip);
+  if (!rec || rec.resetAt <= now) {
+    rec = { count: 0, resetAt: now + WINDOW_SECONDS * 1000 };
+    memory.set(ip, rec);
+  }
+  rec.count++;
+  if (rec.count <= ALLOWED_PER_WINDOW) return { allowed: true, retryAfterSeconds: 0 };
+  return { allowed: false, retryAfterSeconds: Math.max(1, Math.ceil((rec.resetAt - now) / 1000)) };
+}
+
+// Contador de janela fixa no Redis, compartilhado entre instâncias. Segundos até
+// o próximo bucket é o Retry-After para um IP bloqueado.
+async function allowFromRedis(redis: Redis, ip: string): Promise<RateLimitDecision> {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const bucket = Math.floor(nowSec / WINDOW_SECONDS);
+  const key = `${KEY_PREFIX}${ip}:${bucket}`;
+  const count = await redis.incr(key);
+  if (count === 1) await redis.expire(key, WINDOW_SECONDS);
+  if (count <= ALLOWED_PER_WINDOW) return { allowed: true, retryAfterSeconds: 0 };
+  return { allowed: false, retryAfterSeconds: WINDOW_SECONDS - (nowSec % WINDOW_SECONDS) };
+}
+
+// Memoizado por requisição, então generateMetadata + render da mesma página
+// compartilham UMA checagem (e um incremento) — o mesmo padrão de single-flight
+// do loadProfile. Lança GitmonError("rate_limit") quando bloqueado.
+export const checkCardRateLimit = cache(async (): Promise<void> => {
+  let ip = "unknown";
+  try {
+    ip = clientIp(await headers());
+  } catch {
+    // Fora de um escopo de requisição (biblioteca ou teste) — abre o jogo.
+    return;
+  }
+  const redis = await getRedisClient();
+  if (!redis) {
+    const decision = allowFromMemory(ip);
+    if (!decision.allowed) throw blocked(decision);
+    return;
+  }
+  try {
+    const decision = await allowFromRedis(redis, ip);
+    if (!decision.allowed) throw blocked(decision);
+  } catch (e) {
+    if (e instanceof GitmonError) throw e;
+    // Soluço do Redis — mantém o limite, por instância.
+    const decision = allowFromMemory(ip);
+    if (!decision.allowed) throw blocked(decision);
+  }
+});
+
+function blocked(decision: RateLimitDecision): GitmonError {
+  return new GitmonError(
+    "rate_limit",
+    "Muitas buscas deste IP. Tente novamente em alguns minutos.",
+    String(decision.retryAfterSeconds),
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1944,7 +1944,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/tests/unit/radar.test.ts
+++ b/tests/unit/radar.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { polygonPoints, radarGeometry, radarSector } from "@/lib/radar";
+
+const LABELS = ["reach", "community", "volume", "veterancy", "breadth"];
+const SIZE = 240;
+const CENTER = SIZE / 2;
+const RADIUS = CENTER * 0.72;
+
+describe("polygonPoints", () => {
+  it("gera N pontos para N lados", () => {
+    const pts = polygonPoints(5, 80, 120).split(" ");
+    expect(pts).toHaveLength(5);
+    expect(pts.every((p) => /^-?\d+\.?\d*,-?\d+\.?\d*$/.test(p))).toBe(true);
+  });
+
+  it("colapsa no centro quando raio é zero", () => {
+    const pts = polygonPoints(5, 0, 120).split(" ");
+    expect(pts.every((p) => p === "120,120")).toBe(true);
+  });
+
+  it("põe o primeiro eixo no topo", () => {
+    const [first] = polygonPoints(5, 80, 120).split(" ");
+    const [x, y] = first.split(",").map(Number);
+    expect(x).toBeCloseTo(120, 0);
+    expect(y).toBeCloseTo(40, 0);
+  });
+});
+
+describe("radarSector", () => {
+  it("gera wedge com 4 pontos", () => {
+    const pts = radarSector(120, 80, 0, 5).split(" ");
+    expect(pts).toHaveLength(4);
+  });
+
+  it("primeiro ponto é sempre o centro", () => {
+    const pts = radarSector(120, 80, 0, 5).split(" ");
+    expect(pts[0]).toBe("120,120");
+  });
+
+  it("funciona para qualquer eixo", () => {
+    for (let i = 0; i < 5; i++) {
+      const pts = radarSector(120, 80, i, 5).split(" ");
+      expect(pts).toHaveLength(4);
+    }
+  });
+});
+
+describe("radarGeometry", () => {
+  const full = Array(5).fill(99);
+  const zero = Array(5).fill(0);
+
+  it("retorna todos os campos", () => {
+    const geo = radarGeometry(full, LABELS, SIZE);
+    expect(geo).toHaveProperty("center");
+    expect(geo).toHaveProperty("radius");
+    expect(geo).toHaveProperty("vertices");
+    expect(geo).toHaveProperty("points");
+    expect(geo).toHaveProperty("rings");
+    expect(geo).toHaveProperty("sectors");
+    expect(geo).toHaveProperty("labels");
+  });
+
+  it("5 eixos → 5 vértices, 3 anéis, 5 setores, 5 labels", () => {
+    const geo = radarGeometry(full, LABELS, SIZE);
+    expect(geo.vertices).toHaveLength(5);
+    expect(geo.rings).toHaveLength(3);
+    expect(geo.sectors).toHaveLength(5);
+    expect(geo.labels).toHaveLength(5);
+  });
+
+  it("valores满额 → vértices no anel externo", () => {
+    const geo = radarGeometry(full, LABELS, SIZE);
+    geo.vertices.forEach((v) => {
+      const dist = Math.hypot(v.x - CENTER, v.y - CENTER);
+      expect(dist).toBeCloseTo(RADIUS, 0);
+    });
+  });
+
+  it("valores zero → todos os pontos no centro", () => {
+    const geo = radarGeometry(zero, LABELS, SIZE);
+    geo.vertices.forEach((v) => {
+      expect(v.x).toBeCloseTo(CENTER, 0);
+      expect(v.y).toBeCloseTo(CENTER, 0);
+    });
+  });
+
+  it("labels ficam além do anel externo", () => {
+    const geo = radarGeometry(full, LABELS, SIZE);
+    geo.labels.forEach((l) => {
+      const dist = Math.hypot(l.x - CENTER, l.y - CENTER);
+      expect(dist).toBeGreaterThan(RADIUS);
+    });
+  });
+
+  it("primeiro label aponta para cima", () => {
+    const geo = radarGeometry(full, LABELS, SIZE);
+    expect(geo.labels[0].y).toBeLessThan(CENTER);
+  });
+
+  it("funciona para qualquer número de eixos", () => {
+    const values6 = Array(6).fill(50);
+    const labels6 = ["a", "b", "c", "d", "e", "f"];
+    const geo = radarGeometry(values6, labels6, SIZE);
+    expect(geo.vertices).toHaveLength(6);
+    expect(geo.sectors).toHaveLength(6);
+    expect(geo.labels).toHaveLength(6);
+  });
+
+  it("clampa valores acima de 99", () => {
+    const over = [150, 99, 0, 50, 80];
+    const geo = radarGeometry(over, LABELS, SIZE);
+    const at99 = radarGeometry([99, 99, 99, 99, 99], LABELS, SIZE);
+    // primeiro vértice deve estar no mesmo raio que 99
+    const dist = Math.hypot(geo.vertices[0].x - CENTER, geo.vertices[0].y - CENTER);
+    const dist99 = Math.hypot(at99.vertices[0].x - CENTER, at99.vertices[0].y - CENTER);
+    expect(dist).toBeCloseTo(dist99, 0);
+  });
+});

--- a/tests/unit/ratelimit.test.ts
+++ b/tests/unit/ratelimit.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Estes testes prendem as peças puras e independentes de requisição do
+// lib/rateLimit: extração de IP e a janela fixa em memória. O caminho Redis é
+// um INCR+EXPIRE fino, e o checkCardRateLimit em si precisa de um escopo de
+// requisição do Next para valer a pena testar — então é a aritmética da janela
+// que fica presa aqui.
+//
+// O módulo importa next/headers, que o vitest não consegue resolver; o alias
+// aponta para algo inerte para o módulo carregar.
+vi.mock("next/headers", () => ({ headers: async () => new Headers() }));
+
+import {
+  ALLOWED_PER_WINDOW,
+  allowFromMemory,
+  clientIp,
+  WINDOW_SECONDS,
+} from "@/lib/rateLimit";
+
+describe("clientIp", () => {
+  it("pega o primeiro hop de x-forwarded-for", () => {
+    const h = new Headers({ "x-forwarded-for": "203.0.113.9, 10.0.0.1" });
+    expect(clientIp(h)).toBe("203.0.113.9");
+  });
+
+  it("cai para x-real-ip quando x-forwarded-for está ausente", () => {
+    expect(clientIp(new Headers({ "x-real-ip": "198.51.100.4" }))).toBe("198.51.100.4");
+  });
+
+  it("prefere x-forwarded-for sobre x-real-ip quando ambos estão presentes", () => {
+    const h = new Headers({ "x-forwarded-for": "203.0.113.9", "x-real-ip": "198.51.100.4" });
+    expect(clientIp(h)).toBe("203.0.113.9");
+  });
+
+  it("cai para 'unknown' sem headers de proxy", () => {
+    expect(clientIp(new Headers())).toBe("unknown");
+  });
+});
+
+describe("allowFromMemory — janela fixa", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000); // época fixa — a aritmética da janela é determinística
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("permite até o limite, depois bloqueia com Retry-After", () => {
+    for (let i = 0; i < ALLOWED_PER_WINDOW; i++) {
+      expect(allowFromMemory("limit-ip")).toEqual({ allowed: true, retryAfterSeconds: 0 });
+    }
+    const blocked = allowFromMemory("limit-ip");
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterSeconds).toBeGreaterThan(0);
+    expect(blocked.retryAfterSeconds).toBeLessThanOrEqual(WINDOW_SECONDS);
+  });
+
+  it("conta IPs de forma independente", () => {
+    for (let i = 0; i < ALLOWED_PER_WINDOW; i++) allowFromMemory("a");
+    expect(allowFromMemory("a").allowed).toBe(false);
+    expect(allowFromMemory("b").allowed).toBe(true);
+  });
+
+  it("reseta depois que a janela vira", () => {
+    for (let i = 0; i < ALLOWED_PER_WINDOW; i++) allowFromMemory("reset-ip");
+    expect(allowFromMemory("reset-ip").allowed).toBe(false);
+
+    vi.setSystemTime(1_700_000_000_000 + (WINDOW_SECONDS + 1) * 1000);
+    expect(allowFromMemory("reset-ip").allowed).toBe(true);
+  });
+});

--- a/tests/unit/tokens.test.ts
+++ b/tests/unit/tokens.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Prende as decisões do pool de tokens: parsing de env (GITHUB_TOKENS vence
+// GITHUB_TOKEN), hash-sharding determinístico e uniforme, registros de saúde e
+// bench a partir dos headers de rate limit, e failover escolhendo o token mais
+// saudável que não esteja de castigo. Tudo com tokens fake e um Redis em
+// memória — nenhuma credencial real em lugar nenhum.
+
+const store = new Map<string, string>();
+vi.mock("@/lib/cache/redis", () => ({
+  getRedisClient: async () => ({
+    get: async (k: string) => store.get(k) ?? null,
+    set: async (k: string, v: string) => {
+      store.set(k, v);
+    },
+  }),
+}));
+
+import {
+  benchToken,
+  hashLogin,
+  pickFailover,
+  pickToken,
+  recordTokenHealth,
+  tokenPool,
+} from "@/lib/github/tokens";
+
+const key = (idx: number) => `gitmon:ghtoken:v1:${idx}`;
+const nowSec = () => Math.floor(Date.now() / 1000);
+const seed = (idx: number, remaining: number, reset: number) =>
+  store.set(key(idx), JSON.stringify({ remaining, reset }));
+
+beforeEach(() => {
+  store.clear();
+  vi.stubEnv("GITHUB_TOKENS", "tokA, tokB,tokC ,tokD");
+  vi.stubEnv("GITHUB_TOKEN", "");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("tokenPool", () => {
+  it("faz o parsing de GITHUB_TOKENS com trim, indexados em ordem", () => {
+    expect(tokenPool()).toEqual([
+      { token: "tokA", idx: 0 },
+      { token: "tokB", idx: 1 },
+      { token: "tokC", idx: 2 },
+      { token: "tokD", idx: 3 },
+    ]);
+  });
+
+  it("cai para GITHUB_TOKEN como um pool de um", () => {
+    vi.stubEnv("GITHUB_TOKENS", "");
+    vi.stubEnv("GITHUB_TOKEN", "solo");
+    expect(tokenPool()).toEqual([{ token: "solo", idx: 0 }]);
+  });
+
+  it("prefere GITHUB_TOKENS quando os dois estão setados", () => {
+    vi.stubEnv("GITHUB_TOKEN", "solo");
+    expect(tokenPool()).toHaveLength(4);
+  });
+
+  it("é vazio quando nenhum env de token está setado", () => {
+    vi.stubEnv("GITHUB_TOKENS", "");
+    vi.stubEnv("GITHUB_TOKEN", "");
+    expect(tokenPool()).toEqual([]);
+  });
+});
+
+describe("pickToken (hash-shard)", () => {
+  it("é determinístico e insensível a caixa", () => {
+    expect(pickToken("Torvalds")).toEqual(pickToken("torvalds"));
+    expect(pickToken("torvalds")).toEqual(pickToken("torvalds"));
+  });
+
+  it("espalha logins distintos por todo o pool", () => {
+    const counts = [0, 0, 0, 0];
+    for (let i = 0; i < 400; i++) counts[hashLogin(`user-${i}`) % 4]++;
+    // Uniforme, não perfeito: todo token recebe uma fatia relevante (≥10%).
+    for (const c of counts) expect(c).toBeGreaterThanOrEqual(40);
+  });
+
+  it("devolve null para um pool vazio", () => {
+    expect(pickToken("torvalds", [])).toBeNull();
+  });
+});
+
+describe("recordTokenHealth / benchToken", () => {
+  it("guarda remaining/reset parseado dos headers de rate limit", async () => {
+    const reset = nowSec() + 1800;
+    await recordTokenHealth(
+      2,
+      new Headers({ "x-ratelimit-remaining": "3210", "x-ratelimit-reset": String(reset) }),
+    );
+    expect(JSON.parse(store.get(key(2))!)).toEqual({ remaining: 3210, reset });
+  });
+
+  it("não escreve nada quando os headers estão ausentes", async () => {
+    await recordTokenHealth(2, new Headers());
+    expect(store.size).toBe(0);
+  });
+
+  it("põe de castigo com zero restante até pelo menos o horizonte do Retry-After", async () => {
+    await benchToken(1, new Headers({ "retry-after": "300" }));
+    const h = JSON.parse(store.get(key(1))!);
+    expect(h.remaining).toBe(0);
+    expect(h.reset).toBeGreaterThanOrEqual(nowSec() + 299);
+  });
+
+  it("põe de castigo com horizonte de segurança quando nenhum header é utilizável", async () => {
+    await benchToken(1, new Headers());
+    const h = JSON.parse(store.get(key(1))!);
+    expect(h.remaining).toBe(0);
+    expect(h.reset).toBeGreaterThanOrEqual(nowSec() + 119);
+  });
+});
+
+describe("pickFailover", () => {
+  it("nunca devolve o token excluído", async () => {
+    for (let exclude = 0; exclude < 4; exclude++) {
+      const picked = await pickFailover(exclude);
+      expect(picked).not.toBeNull();
+      expect(picked!.idx).not.toBe(exclude);
+    }
+  });
+
+  it("trata saúde desconhecida como token fresco (Redis vazio ainda falha over)", async () => {
+    const picked = await pickFailover(0);
+    expect(picked).toEqual({ token: "tokB", idx: 1 });
+  });
+
+  it("escolhe o candidato mais saudável pela quota restante", async () => {
+    const reset = nowSec() + 1800;
+    seed(1, 1000, reset);
+    seed(2, 3000, reset);
+    seed(3, 500, reset);
+    expect((await pickFailover(0))!.idx).toBe(2);
+  });
+
+  it("pula tokens de castigo (abaixo da folga, reset ainda à frente)", async () => {
+    const reset = nowSec() + 1800;
+    seed(1, 0, reset);
+    seed(2, 150, reset); // abaixo da folga de 200 pontos -> castigo
+    seed(3, 900, reset);
+    expect((await pickFailover(0))!.idx).toBe(3);
+  });
+
+  it("trata token de castigo cuja janela já passou como recarregado", async () => {
+    seed(1, 0, nowSec() - 10); // janela terminou -> fresco de novo
+    seed(2, 3000, nowSec() + 1800);
+    seed(3, 0, nowSec() + 1800);
+    expect((await pickFailover(0))!.idx).toBe(1);
+  });
+
+  it("devolve null quando todo outro token está de castigo", async () => {
+    const reset = nowSec() + 1800;
+    seed(1, 0, reset);
+    seed(2, 10, reset);
+    seed(3, 0, reset);
+    expect(await pickFailover(0)).toBeNull();
+  });
+
+  it("devolve null num pool de um token", async () => {
+    vi.stubEnv("GITHUB_TOKENS", "");
+    vi.stubEnv("GITHUB_TOKEN", "solo");
+    expect(await pickFailover(0)).toBeNull();
+  });
+});


### PR DESCRIPTION
## O que muda

### Infra do GitHub
- **Pool de tokens** (`lib/github/tokens.ts`): suporte a `GITHUB_TOKENS` (contas distintas,
  separadas por vírgula) com seleção por hash sem estado — multiplica o teto da API REST
  (~5k req/h por conta) e continua funcionando com `GITHUB_TOKEN` sozinho. Failover por
  saúde dos tokens via Redis (best-effort).
- **OAuth App** (`lib/github/oauth.ts`): fluxo mínimo de "encontre seu perfil em um clique" —
  sem sessão, token trocado e descartado. Degrada limpo sem env vars. Corrige `baseUrl` → `appBaseUrl`.
- **Rate limit por IP** (`lib/rateLimit.ts`): orçamento de 20 buscas / 10 min por IP, aplicado
  antes do cache/fetch, com contador em memória como fallback quando o Redis não está disponível.
  Responde 429 via `GitmonError`.
- **`client.ts`** refatorado para usar o pool e remover duplicação de `authHeaders`/`token`.

### Descoberta
- **Busca de usuários** (`lib/github/search.ts` + rota `/api/search`): autocomplete de perfis
  por nome na home, com orçamento próprio de rate limit (não rouba do GraphQL) e cache em
  memória de 10 min.

### Batalha e perfil
- **`lib/radar.ts`**: geometria SVG do radar extraída de `ratings.ts` e compartilhada entre
  `RadarChart` e a nova `BattleRadar`.
- **`BattleReplay`/`BattleForm`**: imagens otimizadas, `useEffect`/`useRef`/`inputRef` e
  remoção de estado redundante.

### App/SEO
- `app/icon.svg`, `not-found`, `error`, `robots.ts` e `sitemap.ts`.

### Testes e docs
- Testes unitários para tokens, rate limit e radar; `.env.example` atualizado; CHANGELOG.

**Contribuidor:** @benogoulart