### PR TITLE
feat(dataviz): identidade de série validada e números fora do hover

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -324,8 +324,16 @@ select {
   stroke-linejoin: round;
 }
 
+/*
+ * Anel de 2px na cor do fundo. O vértice cai em cima da linha do polígono e, nos
+ * eixos fortes, em cima de um anel da grade — sem o anel ele deixa de ser um
+ * ponto e vira um engrossamento da linha. Quem separa é o fundo, nunca uma borda
+ * desenhada em volta da marca.
+ */
 .radar-vertex {
   fill: var(--element, var(--accent));
+  stroke: var(--bg);
+  stroke-width: 2;
 }
 
 /* Rótulo em token de texto, nunca na cor da série. */
@@ -362,39 +370,114 @@ select {
 
 .radar-hitzone {
   cursor: pointer;
-  outline: none;
 }
 
-.radar-tooltip {
-  position: absolute;
-  left: 50%;
-  bottom: 0;
-  transform: translateX(-50%) translateY(calc(100% + 8px));
-  z-index: 10;
-  padding: 8px 12px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--bg-raised);
-  box-shadow: 0 10px 28px -8px rgba(0, 0, 0, 0.4);
-  text-align: center;
-  pointer-events: none;
-  animation: pop .16s cubic-bezier(.16,1,.3,1) both;
+/* Foco visível: o setor é transparente, então o contorno é a única prova de onde
+   o teclado está. `outline: none` aqui seria tirar a navegação por teclado. */
+.radar-hitzone:focus-visible {
+  outline: 2px solid var(--element, var(--accent));
+  outline-offset: -2px;
 }
 
-.radar-tooltip-label {
-  font-size: 10px;
+/* ------------------------------------------- valores por eixo (tabela visível) */
+
+/*
+ * A tabela que antes era `visually-hidden`. É `<table>` de verdade — mesma
+ * marcação de antes, mesmo `<th scope="row">` — e agora também é o gráfico:
+ * cada eixo ganha uma barra proporcional ao índice normalizado, que é a leitura
+ * "este eixo é o mais forte deste perfil" sem ter que estimar a área do polígono.
+ */
+.radar-values {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  text-align: left;
+}
+
+.radar-values caption {
+  text-align: left;
+  padding-bottom: 8px;
+  font-size: 11px;
   font-weight: 700;
   letter-spacing: 1px;
   text-transform: uppercase;
   color: var(--text-faint);
 }
 
-.radar-tooltip-value {
+/* A escala vem escrita, e não implícita: o índice é log e o número cru está ao
+   lado, então a legenda tem que dizer qual dos dois a barra desenha. */
+.radar-values caption span {
+  display: block;
   margin-top: 2px;
-  font-size: 19px;
-  font-weight: 900;
-  color: var(--element, var(--accent));
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--text-faint);
+}
+
+.radar-values tr {
+  transition: opacity .25s ease;
+}
+
+.radar-values tr[data-dim] {
+  opacity: 0.4;
+}
+
+.radar-values th[scope="row"] {
+  padding: 5px 10px 5px 0;
+  font-weight: 600;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.radar-values tr[data-active] th[scope="row"] {
+  color: var(--text);
+}
+
+.radar-meter-cell {
+  width: 100%;
+  padding: 5px 10px;
+}
+
+/* Trilho num passo mais claro da própria cor, não em cinza neutro: assim a barra
+   inteira pertence ao tipo e o vazio ainda lê como parte da mesma escala. */
+.radar-meter {
+  display: block;
+  height: 6px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--element, var(--accent)) 16%, var(--bg-sunken));
+  overflow: hidden;
+}
+
+/* Quadrado na linha de base, arredondado na ponta do dado — a ponta é onde o
+   valor termina, e é ela que precisa ser legível como fim. */
+.radar-meter-fill {
+  display: block;
+  height: 100%;
+  border-radius: 0 3px 3px 0;
+  background: var(--element, var(--accent));
+  transition: width .3s cubic-bezier(.22,1,.36,1);
+}
+
+/* Rótulo seletivo: só o eixo mais forte ganha ênfase. Um destaque em toda linha
+   não é destaque. */
+.radar-values tr[data-peak] .radar-meter-fill {
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--element, var(--accent)) 60%, transparent);
+}
+
+.radar-raw {
+  padding: 5px 0;
+  text-align: right;
+  font-weight: 700;
+  color: var(--text-muted);
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.radar-values tr[data-active] .radar-raw,
+.radar-values tr[data-peak] .radar-raw {
+  color: var(--text);
 }
 
 .visually-hidden {
@@ -1416,6 +1499,52 @@ select {
   order: 3;
 }
 
+/*
+ * A tabela de valores também espelha, pela mesma razão que as derivações: nesta
+ * coluna tudo mira a carta, e uma tabela lendo da esquerda para a direita no
+ * meio de um bloco alinhado à direita denuncia que ela foi colada depois.
+ *
+ * `direction: rtl` na tabela e `ltr` nas células inverte a **ordem das colunas**
+ * sem mexer no DOM — a marcação continua rótulo → barra → valor, que é a ordem
+ * que o leitor de tela deve ouvir. Reordenar de verdade só para o olho custaria
+ * a semântica da tabela.
+ */
+.card-aside-left .radar-values {
+  direction: rtl;
+}
+
+.card-aside-left .radar-values th,
+.card-aside-left .radar-values td,
+.card-aside-left .radar-values caption {
+  direction: ltr;
+}
+
+.card-aside-left .radar-values caption,
+.card-aside-left .radar-values th[scope="row"] {
+  text-align: right;
+}
+
+.card-aside-left .radar-values th[scope="row"] {
+  padding: 5px 0 5px 10px;
+}
+
+/*
+ * O número **não** vai para a borda de fora como o valor das derivações vai.
+ * Coluna de número alinha pela direita, espelhada ou não: encostados na barra os
+ * dígitos empilham; jogados na borda esquerda, "254.470" e "2" ficam pendurados
+ * em pontos diferentes e não dá para comparar ordem de grandeza de relance.
+ */
+.card-aside-left .radar-raw {
+  padding: 5px 0 5px 10px;
+}
+
+/* A barra cresce da borda de fora para dentro, mirando a carta como o resto da
+   coluna. A ponta arredondada acompanha: é ela que marca onde o dado termina. */
+.card-aside-left .radar-meter-fill {
+  margin-left: auto;
+  border-radius: 3px 0 0 3px;
+}
+
 /* Embed e batalha voltam a ocupar a largura toda, abaixo das três colunas. */
 .card-panel > .card-side {
   grid-column: 1 / -1;
@@ -1448,6 +1577,30 @@ select {
     order: 0;
     text-align: right;
     justify-content: flex-end;
+  }
+
+  /* Coluna única: o espelho se desfaz aqui também, senão a tabela fica sendo a
+     única coisa da página lendo da direita para a esquerda. */
+  .card-aside-left .radar-values {
+    direction: ltr;
+  }
+
+  .card-aside-left .radar-values caption,
+  .card-aside-left .radar-values th[scope="row"] {
+    text-align: left;
+  }
+
+  .card-aside-left .radar-values th[scope="row"] {
+    padding: 5px 10px 5px 0;
+  }
+
+  .card-aside-left .radar-raw {
+    padding: 5px 0;
+  }
+
+  .card-aside-left .radar-meter-fill {
+    margin-left: 0;
+    border-radius: 0 3px 3px 0;
   }
 }
 
@@ -1687,14 +1840,21 @@ select {
 .fighter-head {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 10px;
+  justify-content: center;
+  gap: 7px;
+  max-width: 100%;
 }
 
 .fighter-head strong {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* O marcador do lado — mesma forma dos vértices do radar e das linhas do log.
+   `flex: none` para não achatar em elipse quando o nome é longo. */
+.side-mark {
+  flex: none;
 }
 
 .fighter-won {
@@ -1722,17 +1882,65 @@ select {
   color: var(--text-faint);
 }
 
+.fighter-hp small {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+/*
+ * O medidor de PS.
+ *
+ * Trilho num passo mais claro da cor do lado, e não no cinza da borda: com o
+ * trilho neutro a barra é uma listra colorida em cima de um fundo qualquer, e
+ * "quase morto" difere de "quase inteiro" só pelo comprimento dessa listra. Com
+ * o trilho tingido, a barra inteira pertence ao lutador e o estado se lê de
+ * ponta a ponta.
+ */
 .fighter-track {
-  height: 8px;
-  border-radius: 4px;
-  background: var(--border);
+  position: relative;
+  width: 100%;
+  height: 10px;
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--side, var(--accent)) 18%, var(--bg-sunken));
   overflow: hidden;
 }
 
-.fighter-fill {
+.fighter-fill,
+.fighter-ghost {
+  position: absolute;
+  inset: 0 auto 0 0;
   height: 100%;
-  border-radius: 4px;
+  /* Quadrada na base, arredondada na ponta do dado. */
+  border-radius: 0 5px 5px 0;
+}
+
+.fighter-fill {
+  background: var(--side, var(--accent));
   transition: width 400ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/*
+ * O rastro do golpe: o pedaço que estava vivo até o turno anterior, desenhado
+ * onde ele estava e apagando em seguida.
+ *
+ * Sem ele, um golpe de 10 e um de 60 têm a mesma aparência — a barra encolhe nos
+ * dois casos, e o que mudou já passou quando o olho chega. O rastro é o dano do
+ * turno, na escala da barra, no lugar de onde ele saiu. `key={turn}` no React
+ * remonta o elemento a cada turno, que é o que reinicia a animação.
+ */
+.fighter-ghost {
+  background: color-mix(in srgb, var(--side, var(--accent)) 55%, transparent);
+  animation: hp-hit 620ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  pointer-events: none;
+}
+
+@keyframes hp-hit {
+  0% { opacity: 1; }
+  35% { opacity: 1; }
+  100% { opacity: 0; }
 }
 
 .replay-log {
@@ -1745,13 +1953,35 @@ select {
   font-size: 14px;
 }
 
+/*
+ * Trilho de 2px na cor de quem está atacando, na borda de dentro.
+ *
+ * O log é o único lugar da página onde os dois lados se alternam na mesma
+ * coluna, e sem marca de autoria cada linha lê como texto corrido — era preciso
+ * ler o nome até o fim para saber de quem era o turno. Com o trilho, a
+ * alternância de quem bate se vê antes de ler qualquer palavra.
+ */
 .replay-log li {
   display: flex;
-  gap: 12px;
+  align-items: baseline;
+  gap: 10px;
   padding: 9px 12px;
   border-radius: 8px;
   background: var(--bg-raised);
+  box-shadow: inset 2px 0 0 var(--turn-side, transparent);
   animation: log-in 260ms ease both;
+}
+
+.replay-log li[data-side="a"] {
+  --turn-side: var(--side-a);
+}
+
+.replay-log li[data-side="b"] {
+  --turn-side: var(--side-b);
+}
+
+.replay-log .side-mark {
+  align-self: center;
 }
 
 @keyframes log-in {
@@ -1855,12 +2085,22 @@ select {
   text-align: center;
 }
 
+/* Legenda sempre presente — são duas séries, e nenhuma identidade neste gráfico
+   pode depender de o leitor casar duas cores de memória. */
 .battle-radar-legend {
   display: flex;
   justify-content: center;
-  gap: 20px;
+  flex-wrap: wrap;
+  gap: 8px 20px;
 }
 
+/*
+ * O nome vai em token de texto, nunca na cor da série: azul e laranja funcionam
+ * como marca de 10px e são ruins como texto de 13px sobre a superfície escura.
+ * Quem carrega a identidade é o marcador ao lado — e ele é a **mesma forma**
+ * desenhada nos vértices do radar, não uma bolinha genérica, senão a legenda
+ * não explica a segunda pista.
+ */
 .battle-radar-legend-item {
   display: flex;
   align-items: center;
@@ -1870,11 +2110,8 @@ select {
   color: var(--text-muted);
 }
 
-.battle-radar-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex-shrink: 0;
+.battle-radar-legend-item svg {
+  flex: none;
 }
 
 .battle-radar-svg-wrap {
@@ -1890,53 +2127,190 @@ select {
 }
 
 .battle-radar-shape {
-  fill-opacity: 0.28;
-  stroke-width: 1.4;
+  stroke-width: 2;
   stroke-linejoin: round;
   transition: fill-opacity .25s ease, stroke-opacity .25s ease;
 }
 
+/* Anel de 2px na superfície: os dois conjuntos de vértices se cruzam, e sem o
+   anel dois marcadores encostados viram uma mancha só. */
+.battle-radar-marker {
+  stroke: var(--bg-raised);
+  stroke-width: 2;
+  transition: opacity .25s ease;
+}
+
+/* O setor em destaque marca um **eixo**, não um lado — por isso neutro. Pintá-lo
+   com a cor de um dos dois diria que aquele eixo pertence a alguém. */
 .battle-radar-sector {
+  fill: var(--text);
+  fill-opacity: 0.07;
+  stroke: var(--border-strong);
   stroke-width: 1;
   animation: pop .16s cubic-bezier(.16,1,.3,1) both;
 }
 
 .battle-radar-hitzone {
   cursor: pointer;
-  outline: none;
 }
 
-.battle-radar-tooltip {
-  position: absolute;
-  left: 50%;
-  bottom: 0;
-  transform: translateX(-50%) translateY(calc(100% + 8px));
-  z-index: 10;
-  padding: 8px 12px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--bg-raised);
-  box-shadow: 0 10px 28px -8px rgba(0, 0, 0, 0.4);
-  text-align: center;
-  pointer-events: none;
-  animation: pop .16s cubic-bezier(.16,1,.3,1) both;
+.battle-radar-hitzone:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 
-.battle-radar-tooltip-label {
-  font-size: 10px;
+/* --------------------------------------------------- comparação eixo a eixo */
+
+/*
+ * A tabela é o gráfico, e o gráfico é a tabela.
+ *
+ * O radar mostra *que* os dois perfis têm formatos diferentes; ele é ruim para
+ * dizer *quanto*, porque comparar duas áreas irregulares a olho não funciona e
+ * nos eixos empatados os polígonos se encavalam. Cada linha aqui põe os dois
+ * valores numa régua só, ligados por um traço: o comprimento do traço **é** a
+ * vantagem, e ela se lê sem hover e sem estimar área.
+ */
+.axis-compare {
+  width: 100%;
+  max-width: 460px;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.axis-compare caption {
+  padding-bottom: 10px;
+  font-size: 11px;
   font-weight: 700;
   letter-spacing: 1px;
   text-transform: uppercase;
   color: var(--text-faint);
+  text-align: center;
 }
 
-.battle-radar-tooltip-values {
-  display: flex;
-  gap: 12px;
-  margin-top: 4px;
-  font-size: 13px;
+.axis-compare caption span {
+  display: block;
+  margin-top: 2px;
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.axis-compare thead th {
+  padding: 0 8px 6px;
+  font-size: 10px;
   font-weight: 700;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  text-align: center;
+}
+
+/* O nome do oponente pode ser longo; a coluna é estreita de propósito, então ele
+   trunca em vez de esticar a régua. A legenda acima já traz o nome inteiro. */
+.axis-compare-name {
+  max-width: 110px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.axis-compare thead th:first-child {
+  text-align: left;
+}
+
+.axis-compare tbody tr {
+  transition: opacity .25s ease;
+}
+
+.axis-compare tbody tr[data-dim] {
+  opacity: 0.4;
+}
+
+.axis-compare th[scope="row"] {
+  padding: 7px 10px 7px 0;
+  font-weight: 600;
+  text-align: left;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.axis-compare tr[data-active] th[scope="row"] {
+  color: var(--text);
+}
+
+/*
+ * O número de quem lidera fica em tinta cheia e peso alto; o outro recua. A
+ * vantagem não é marcada com cor de série — a cor já está nos pontos da régua ao
+ * lado, e número colorido é justamente o que não se lê nesta superfície.
+ */
+.axis-compare-value {
+  padding: 7px 8px;
+  text-align: center;
+  color: var(--text-faint);
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
+}
+
+.axis-compare-value[data-lead] {
+  color: var(--text);
+  font-weight: 800;
+}
+
+.axis-compare-track-cell {
+  width: 100%;
+  padding: 7px 10px;
+}
+
+.axis-compare-track {
+  position: relative;
+  display: block;
+  height: 14px;
+}
+
+/* Régua de 0 a 99, hairline e uma sombra acima da superfície: é estrutura. */
+.axis-compare-rail {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--border);
+}
+
+.axis-compare-link {
+  position: absolute;
+  top: 50%;
+  height: 2px;
+  transform: translateY(-50%);
+  border-radius: 1px;
+  background: var(--border-strong);
+}
+
+/*
+ * Os dois pontos da régua. Anel de 2px na cor da superfície porque nos eixos
+ * empatados eles se sobrepõem — sem o anel viram um ponto só, que é exatamente a
+ * leitura errada ("um dos dois sumiu" em vez de "estão empatados").
+ */
+.axis-compare-dot {
+  position: absolute;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  margin-left: -5px;
+  margin-top: -5px;
+  box-shadow: 0 0 0 2px var(--bg-raised);
+}
+
+.axis-compare-dot[data-shape="circle"] {
+  border-radius: 50%;
+}
+
+/* O losango é o mesmo quadrado girado — a segunda pista de identidade, a que
+   sobrevive a cinza, a daltonismo e a `forced-colors`. */
+.axis-compare-dot[data-shape="diamond"] {
+  border-radius: 1px;
+  transform: rotate(45deg);
 }
 
 @keyframes pop {

--- a/components/battle/BattleRadar.tsx
+++ b/components/battle/BattleRadar.tsx
@@ -3,18 +3,30 @@
 import { useState } from "react";
 import { AXES } from "@/lib/cards/ratings";
 import type { Card } from "@/lib/cards/types";
-import { ELEMENT_COLORS } from "@/lib/cards/elements";
 import { radarGeometry, radarSector } from "@/lib/radar";
+import { SIDE_COLORS, SIDE_MARKERS, markerPath } from "@/lib/viz/series";
+import { TypeIcon } from "@/components/card/TypeIcon";
 import { translator, type Locale, type MessageKey } from "@/lib/i18n/dictionaries";
 
 const SIZE = 240;
 
 /**
- * Radar comparativo de batalha: dois polígonos sobrepostos no mesmo eixo.
+ * Radar comparativo de batalha: dois polígonos sobrepostos no mesmo eixo, mais a
+ * tabela eixo a eixo que responde a pergunta que o radar sozinho não responde.
  *
- * A sobreposição mostra visualmente onde cada oponente leva vantagem — a forma
- * do polígono é a "assinatura" do perfil, e onde um polígono se estende além
- * do outro, aquele lado domina naquele eixo.
+ * **A cor da série não é a cor do tipo** — ver `lib/viz/series.ts` para os
+ * números que provam por quê. Resumo: dois devs de JavaScript são os dois
+ * `electric`, e o radar desenhava dois polígonos idênticos. Agora cada lado tem
+ * um slot fixo (azul/laranja, validados), o tipo continua presente no disco ao
+ * lado do nome, e o vértice de cada lado tem forma própria — assim a identidade
+ * sobrevive a daltonismo, impressão em cinza e `forced-colors`.
+ *
+ * A sobreposição mostra de relance *que* os perfis têm formatos diferentes. Ela
+ * é ruim para dizer *quanto* — comparar duas áreas irregulares a olho não
+ * funciona, e nos eixos onde os dois estão perto os polígonos se encavalam. Por
+ * isso a tabela embaixo, com uma linha por eixo: dois pontos numa mesma régua,
+ * ligados por um traço cujo comprimento **é** a vantagem. Ali "quem é mais
+ * forte em Alcance" se lê sem hover e sem estimar área.
  */
 export function BattleRadar({
   a,
@@ -37,10 +49,9 @@ export function BattleRadar({
 
   const geoA = radarGeometry(valuesA, labels, SIZE);
   const geoB = radarGeometry(valuesB, labels, SIZE);
-  const geo = geoA; // rings/labels/sectors are shared
+  const geo = geoA; // rings/labels/sectors são compartilhados
 
-  const colorsA = ELEMENT_COLORS[a.element];
-  const colorsB = ELEMENT_COLORS[b.element];
+  const dimmed = (i: number) => active !== null && active !== i;
 
   return (
     <figure className="battle-radar">
@@ -49,83 +60,96 @@ export function BattleRadar({
         <p>{t("battle.radarCaption")}</p>
       </figcaption>
 
+      {/*
+        Legenda sempre presente, porque são duas séries. O nome vai em token de
+        texto e nunca na cor da série: o laranja e o azul são legíveis como
+        marca de 10px e ruins como texto de 13px sobre a superfície escura. Quem
+        carrega a identidade é o marcador ao lado — que é a mesma forma desenhada
+        nos vértices do radar, não uma bolinha genérica.
+      */}
       <div className="battle-radar-legend">
-        <span className="battle-radar-legend-item">
-          <span className="battle-radar-dot" style={{ background: colorsA.base }} />
-          {a.name}
-        </span>
-        <span className="battle-radar-legend-item">
-          <span className="battle-radar-dot" style={{ background: colorsB.base }} />
-          {b.name}
-        </span>
+        {(["a", "b"] as const).map((side) => {
+          const card = side === "a" ? a : b;
+          return (
+            <span key={side} className="battle-radar-legend-item">
+              <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+                <path
+                  d={markerPath(SIDE_MARKERS[side], 7, 7, 5)}
+                  fill={SIDE_COLORS[side]}
+                />
+              </svg>
+              <TypeIcon element={card.element} size={14} />
+              {card.name}
+            </span>
+          );
+        })}
       </div>
 
       <div className="battle-radar-svg-wrap">
-        <svg viewBox={`0 0 ${SIZE} ${SIZE}`} className="battle-radar-svg">
+        <svg viewBox={`0 0 ${SIZE} ${SIZE}`} className="battle-radar-svg" role="img"
+          aria-label={`${t("battle.radar")}: ${a.name}, ${b.name}`}>
           {geo.rings.map((ring, i) => (
             <polygon key={i} points={ring} className="radar-grid" />
           ))}
 
-          {active !== null && (
-            <polygon
-              points={geo.sectors[active]}
-              className="battle-radar-sector"
-              style={{ fill: `${colorsA.base}18`, stroke: `${colorsA.base}40` }}
+          {geo.axes.map((end, i) => (
+            <line
+              key={i}
+              x1={geo.center}
+              y1={geo.center}
+              x2={end.x}
+              y2={end.y}
+              className="radar-spoke"
             />
+          ))}
+
+          {active !== null && (
+            <polygon points={geo.sectors[active]} className="battle-radar-sector" />
           )}
 
-          <polygon
-            points={geoA.points}
-            className="battle-radar-shape"
-            style={{
-              fill: `${colorsA.base}${active !== null ? "22" : "30"}`,
-              stroke: colorsA.base,
-              strokeOpacity: active !== null ? 0.55 : 1,
-            }}
-          />
-          <polygon
-            points={geoB.points}
-            className="battle-radar-shape"
-            style={{
-              fill: `${colorsB.base}${active !== null ? "22" : "30"}`,
-              stroke: colorsB.base,
-              strokeOpacity: active !== null ? 0.55 : 1,
-            }}
-          />
+          {/*
+            Preenchimento leve (16%) em vez dos 28% de antes: são duas áreas que
+            se cruzam, e a região de sobreposição soma as duas. A 28% cada, o
+            miolo virava um bloco chapado onde nenhum dos dois contornos se
+            lia — que é justamente onde a comparação acontece.
+          */}
+          {(["a", "b"] as const).map((side) => (
+            <polygon
+              key={side}
+              points={side === "a" ? geoA.points : geoB.points}
+              className="battle-radar-shape"
+              style={{
+                fill: SIDE_COLORS[side],
+                fillOpacity: active !== null ? 0.1 : 0.16,
+                stroke: SIDE_COLORS[side],
+                strokeOpacity: active !== null ? 0.55 : 1,
+              }}
+            />
+          ))}
 
-          {geoA.vertices.map((v, i) => (
-            <circle
-              key={`a-${i}`}
-              cx={v.x}
-              cy={v.y}
-              r={active === i ? 3.5 : 2}
-              fill={colorsA.base}
-              opacity={active !== null && active !== i ? 0.3 : 1}
-              style={{ transition: "r .2s ease, opacity .25s ease" }}
-            />
-          ))}
-          {geoB.vertices.map((v, i) => (
-            <circle
-              key={`b-${i}`}
-              cx={v.x}
-              cy={v.y}
-              r={active === i ? 3.5 : 2}
-              fill={colorsB.base}
-              opacity={active !== null && active !== i ? 0.3 : 1}
-              style={{ transition: "r .2s ease, opacity .25s ease" }}
-            />
-          ))}
+          {(["a", "b"] as const).map((side) =>
+            (side === "a" ? geoA : geoB).vertices.map((v, i) => (
+              <path
+                key={`${side}-${i}`}
+                d={markerPath(SIDE_MARKERS[side], v.x, v.y, active === i ? 5 : 4)}
+                fill={SIDE_COLORS[side]}
+                className="battle-radar-marker"
+                opacity={dimmed(i) ? 0.3 : 1}
+              />
+            )),
+          )}
 
           {geo.labels.map((l, i) => (
             <text
               key={i}
               x={l.x}
               y={l.y}
-              textAnchor="middle"
+              textAnchor={l.anchor}
               dominantBaseline="middle"
               className="radar-label"
               fill={active === i ? "var(--text)" : "var(--text-faint)"}
-              style={{ transition: "fill .2s ease" }}
+              opacity={dimmed(i) ? 0.3 : 1}
+              style={{ transition: "fill .2s ease, opacity .25s ease" }}
             >
               {l.label}
             </text>
@@ -137,27 +161,134 @@ export function BattleRadar({
               points={radarSector(geo.center, geo.radius + 17, i, AXES.length)}
               fill="transparent"
               className="battle-radar-hitzone"
+              tabIndex={0}
+              role="button"
+              aria-label={`${labels[i]}: ${a.name} ${valuesA[i]}, ${b.name} ${valuesB[i]}`}
               onMouseEnter={() => setActive(i)}
               onMouseLeave={() => setActive(null)}
+              onFocus={() => setActive(i)}
+              onBlur={() => setActive(null)}
               onClick={() => setActive((prev) => (prev === i ? null : i))}
             />
           ))}
         </svg>
-
-        {active !== null && (
-          <div className="battle-radar-tooltip">
-            <div className="battle-radar-tooltip-label">{labels[active]}</div>
-            <div className="battle-radar-tooltip-values">
-              <span style={{ color: colorsA.base }}>
-                {a.name}: {valuesA[active]}
-              </span>
-              <span style={{ color: colorsB.base }}>
-                {b.name}: {valuesB[active]}
-              </span>
-            </div>
-          </div>
-        )}
       </div>
+
+      <AxisCompare
+        a={a}
+        b={b}
+        valuesA={valuesA}
+        valuesB={valuesB}
+        labels={labels}
+        active={active}
+        onActive={setActive}
+        locale={locale}
+      />
     </figure>
+  );
+}
+
+/**
+ * Uma linha por eixo: os dois valores numa régua só, ligados por um traço.
+ *
+ * É a "table view" do radar e um gráfico ao mesmo tempo — `<table>` de verdade,
+ * com `<th scope="row">` por eixo, então leitor de tela lê a comparação linha a
+ * linha sem depender de nenhuma geometria.
+ *
+ * Os números são o índice 0–99, e não a métrica crua, porque é o índice que os
+ * pontos desenham. Imprimir "254.000 estrelas" ao lado de um ponto posicionado
+ * por log(254.000) seria uma legenda que discorda do próprio gráfico. A legenda
+ * da tabela diz o que o índice é.
+ */
+function AxisCompare({
+  a,
+  b,
+  valuesA,
+  valuesB,
+  labels,
+  active,
+  onActive,
+  locale,
+}: {
+  a: Card;
+  b: Card;
+  valuesA: number[];
+  valuesB: number[];
+  labels: string[];
+  active: number | null;
+  onActive: (i: number | null) => void;
+  locale: Locale;
+}) {
+  const t = translator(locale);
+
+  return (
+    <table className="axis-compare">
+      <caption>
+        {t("battle.axisCompare")} <span>{t("radar.normalized")}</span>
+      </caption>
+      <thead>
+        <tr>
+          <th scope="col">{t("radar.axis")}</th>
+          <th scope="col" className="axis-compare-name">{a.name}</th>
+          <th scope="col">
+            <span className="visually-hidden">{t("battle.lead")}</span>
+          </th>
+          <th scope="col" className="axis-compare-name">{b.name}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {labels.map((label, i) => {
+          const va = valuesA[i];
+          const vb = valuesB[i];
+          const lo = Math.min(va, vb);
+          const hi = Math.max(va, vb);
+          const leader = va === vb ? null : va > vb ? "a" : "b";
+
+          return (
+            <tr
+              key={label}
+              data-active={active === i || undefined}
+              data-dim={(active !== null && active !== i) || undefined}
+              onMouseEnter={() => onActive(i)}
+              onMouseLeave={() => onActive(null)}
+            >
+              <th scope="row">{label}</th>
+              <td className="axis-compare-value" data-lead={leader === "a" || undefined}>
+                {va}
+              </td>
+              <td className="axis-compare-track-cell">
+                <span className="axis-compare-track" aria-hidden="true">
+                  <span className="axis-compare-rail" />
+                  {/* O traço entre os dois pontos: o comprimento dele é a vantagem. */}
+                  <span
+                    className="axis-compare-link"
+                    style={{ left: `${lo}%`, width: `${hi - lo}%` }}
+                  />
+                  {(["a", "b"] as const).map((side) => (
+                    <span
+                      key={side}
+                      className="axis-compare-dot"
+                      data-shape={SIDE_MARKERS[side]}
+                      style={{
+                        left: `${side === "a" ? va : vb}%`,
+                        background: SIDE_COLORS[side],
+                      }}
+                    />
+                  ))}
+                </span>
+                <span className="visually-hidden">
+                  {leader === null
+                    ? t("battle.tie")
+                    : `${leader === "a" ? a.name : b.name} ${t("battle.lead")} +${hi - lo}`}
+                </span>
+              </td>
+              <td className="axis-compare-value" data-lead={leader === "b" || undefined}>
+                {vb}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
   );
 }

--- a/components/battle/BattleReplay.tsx
+++ b/components/battle/BattleReplay.tsx
@@ -3,8 +3,9 @@
 import Image from "next/image";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { BattleResult, Side } from "@/lib/battle/types";
-import { ELEMENT_COLORS } from "@/lib/cards/elements";
-import type { Card, Element } from "@/lib/cards/types";
+import type { Card } from "@/lib/cards/types";
+import { SIDE_COLORS, SIDE_MARKERS, markerPath } from "@/lib/viz/series";
+import { TypeIcon } from "@/components/card/TypeIcon";
 import { translator, type Locale } from "@/lib/i18n/dictionaries";
 import { BattleRadar } from "./BattleRadar";
 
@@ -14,9 +15,23 @@ import { BattleRadar } from "./BattleRadar";
  * O log existe só para isto (RFC 7.3, item 7): não é persistido como parte do
  * que se compartilha e não entra na imagem — o pôster mostra só o placar final.
  * Tudo aqui é client-side, sem nenhuma implicação em cache ou geração de imagem.
+ *
+ * A cor de cada lado vem de `lib/viz/series.ts`, e não do tipo da carta. Vale a
+ * mesma razão do radar: dois oponentes do mesmo tipo tinham a mesma barra de PS,
+ * e a barra é o único lugar da tela onde os dois aparecem lado a lado. O tipo
+ * continua na tela, no disco ao lado do nome.
  */
 
 const TURN_MS = 850;
+
+/** Marcador do lado, do tamanho de um caractere — a mesma forma dos vértices do radar. */
+function SideMark({ side }: { side: Side }) {
+  return (
+    <svg className="side-mark" width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+      <path d={markerPath(SIDE_MARKERS[side], 5, 5, 4)} fill={SIDE_COLORS[side]} />
+    </svg>
+  );
+}
 
 export function BattleReplay({
   battle,
@@ -43,43 +58,80 @@ export function BattleReplay({
     if (last) last.scrollIntoView({ behavior: "smooth", block: "end" });
   }, [played]);
 
-  /** HP de cada lado depois dos turnos já tocados. */
-  const hp = useMemo(() => {
+  /**
+   * HP de cada lado depois dos turnos já tocados, e o de um turno atrás.
+   *
+   * O anterior existe para a barra mostrar **o pedaço que acabou de sair**: numa
+   * barra que só encolhe, um golpe de 10 e um de 60 têm a mesma aparência —
+   * a barra está sempre em algum lugar, e o que mudou já foi. O rastro é o dano
+   * do turno, desenhado no lugar de onde ele saiu.
+   */
+  const { hp, prevHp } = useMemo(() => {
     const current: Record<Side, number> = { a: battle.a.hp, b: battle.b.hp };
-    for (const turn of battle.turns.slice(0, played)) {
+    let previous: Record<Side, number> = { ...current };
+
+    battle.turns.slice(0, played).forEach((turn, i) => {
+      if (i === played - 1) previous = { ...current };
       const defender: Side = turn.attacker === "a" ? "b" : "a";
       current[defender] = Math.max(0, current[defender] - turn.damage);
-    }
-    return current;
+    });
+
+    return { hp: current, prevHp: previous };
   }, [battle, played]);
 
   const finished = played >= battle.turns.length;
 
+  /*
+   * As duas cores de série descem daqui como variáveis para o CSS pintar o
+   * trilho de cada linha do log. A fonte continua sendo `lib/viz/series.ts` — o
+   * CSS lê o valor, não o redefine, para não haver duas listas de cor.
+   */
   return (
-    <div className="replay">
+    <div
+      className="replay"
+      style={{
+        ["--side-a" as string]: SIDE_COLORS.a,
+        ["--side-b" as string]: SIDE_COLORS.b,
+      }}
+    >
       <div className="replay-fighters">
         <FighterBar
+          side="a"
           card={battle.a}
           hp={hp.a}
+          prevHp={prevHp.a}
+          turn={played}
           won={finished && battle.winner === "a"}
           label={t("battle.winner")}
+          hpLabel={t("battle.hpLeft")}
         />
         <span className="replay-vs">VS</span>
         <FighterBar
+          side="b"
           card={battle.b}
           hp={hp.b}
+          prevHp={prevHp.b}
+          turn={played}
           won={finished && battle.winner === "b"}
           label={t("battle.winner")}
+          hpLabel={t("battle.hpLeft")}
         />
       </div>
 
-      <ol className="replay-log" aria-live="polite">
+      <ol className="replay-log" ref={logRef} aria-live="polite">
         {battle.turns.slice(0, played).map((turn) => {
           const attacker = turn.attacker === "a" ? battle.a : battle.b;
           const defender = turn.attacker === "a" ? battle.b : battle.a;
 
           return (
-            <li key={turn.index}>
+            <li key={turn.index} data-side={turn.attacker}>
+              {/*
+                Trilho e marcador na cor do atacante. O log é a única parte da
+                página onde os dois lados se alternam na mesma coluna, e sem uma
+                marca de quem está batendo cada linha lê como texto corrido — é
+                preciso ler o nome até o fim para saber de quem é o turno.
+              */}
+              <SideMark side={turn.attacker} />
               <span className="turn-index">{t("battle.turn", { n: turn.index })}</span>
               {turn.attack === null ? (
                 <span className="turn-body">{attacker.name} —</span>
@@ -129,21 +181,37 @@ export function BattleReplay({
 }
 
 function FighterBar({
+  side,
   card,
   hp,
+  prevHp,
+  turn,
   won,
   label,
+  hpLabel,
 }: {
+  side: Side;
   card: Card;
   hp: number;
+  /** HP antes do último turno tocado — de onde sai o rastro de dano. */
+  prevHp: number;
+  /** Só para reiniciar a animação do rastro a cada turno. */
+  turn: number;
   won: boolean;
   label: string;
+  hpLabel: string;
 }) {
-  const colors = ELEMENT_COLORS[card.element];
-  const ratio = Math.max(0, Math.min(1, hp / Math.max(1, card.hp)));
+  const max = Math.max(1, card.hp);
+  const ratio = Math.max(0, Math.min(1, hp / max));
+  const prevRatio = Math.max(ratio, Math.min(1, prevHp / max));
+  const color = SIDE_COLORS[side];
 
   return (
-    <div className="fighter-bar" data-won={won || undefined}>
+    <div
+      className="fighter-bar"
+      data-won={won || undefined}
+      style={{ ["--side" as string]: color }}
+    >
       <Image
         src={`/${card.id}.png`}
         alt={card.name}
@@ -152,18 +220,41 @@ function FighterBar({
         className="fighter-card-img"
       />
       <div className="fighter-head">
+        <SideMark side={side} />
+        <TypeIcon element={card.element} size={16} />
         <strong>{card.name}</strong>
         {won ? <span className="fighter-won">{label}</span> : null}
       </div>
       <div className="fighter-hp">
         <span>{hp}</span>
         <i>/ {card.hp}</i>
+        <small>{hpLabel}</small>
       </div>
-      <div className="fighter-track">
-        <div
-          className="fighter-fill"
-          style={{ width: `${ratio * 100}%`, background: colors.base }}
-        />
+      {/*
+        Medidor: trilho num passo mais claro da própria cor do lado, e não no
+        cinza da borda. Com o trilho neutro, "quase morto" e "quase inteiro"
+        diferem só no comprimento de uma listra; com o trilho tingido, a barra
+        inteira pertence ao lado e o estado se lê de ponta a ponta.
+      */}
+      <div
+        className="fighter-track"
+        role="meter"
+        aria-valuenow={hp}
+        aria-valuemin={0}
+        aria-valuemax={card.hp}
+        aria-label={`${card.name} — ${hpLabel}`}
+      >
+        {/* Só existe quando há pedaço perdido para mostrar: no turno em que este
+            lado não apanhou, um rastro de largura zero seria uma animação a
+            cada 850ms sem nada acontecendo. */}
+        {prevRatio > ratio ? (
+          <div
+            key={turn}
+            className="fighter-ghost"
+            style={{ width: `${prevRatio * 100}%` }}
+          />
+        ) : null}
+        <div className="fighter-fill" style={{ width: `${ratio * 100}%` }} />
       </div>
     </div>
   );

--- a/components/card/RadarChart.tsx
+++ b/components/card/RadarChart.tsx
@@ -15,12 +15,35 @@ import { translator, type Locale, type MessageKey } from "@/lib/i18n/dictionarie
  *   independentes e tetos escolhidos por nós; uma régua numerada prometeria uma
  *   precisão que a normalização não sustenta. Os anéis de grade existem só para
  *   dar profundidade, e por isso não são rotulados.
- * - **Os números reais ficam fora daqui**, na lista de derivações ao lado. O
- *   radar dá a forma; a lista dá o dado.
  * - **Uma série só, logo sem legenda.** O título nomeia o que está plotado.
- * - **`<table>` escondida** com os valores crus: a forma é inacessível para
- *   leitor de tela, e cor/geometria nunca podem ser o único caminho para o dado.
+ *
+ * O que mudou: os números **saíram do hover**. Antes eles moravam numa
+ * `<table class="visually-hidden">` e num tooltip — ou seja, a única forma de
+ * ler um valor com os olhos era acertar o mouse em cima de um setor. Tooltip
+ * complementa, nunca é o único caminho para o dado. Agora a mesma tabela é
+ * visível abaixo do radar, com uma barra por eixo, e continua sendo `<table>` de
+ * verdade para leitor de tela. O radar dá a forma; a tabela dá o dado — que é
+ * exatamente o que `ratings.ts` sempre defendeu, só que agora dá de fato.
+ *
+ * A régua da tabela é honesta sobre o que é: a legenda diz "índice 0–99, escala
+ * logarítmica" e o número cru fica ao lado. A objeção de `ratings.ts` era a
+ * régua **no radar**, onde a forma promete comparação entre eixos; numa lista,
+ * cada eixo é lido sozinho e o índice não mente sobre nada.
  */
+/**
+ * O número cru, pronto para exibir.
+ *
+ * `Math.floor` pelo mesmo motivo que `profile.ts` já aplica na linha de recuo:
+ * `yearsSince` devolve fração, e "14,937808668117981" não é dado, é vazamento de
+ * implementação. Enquanto o valor vivia escondido no tooltip dava para não
+ * reparar; numa coluna ao lado de "254.470" e "316.307", um "14,945" em pt-BR lê
+ * como quatorze mil. Os outros quatro eixos já são inteiros, então o piso não
+ * muda nada neles.
+ */
+function formatRaw(raw: number, locale: Locale): string {
+  return Math.floor(raw).toLocaleString(locale);
+}
+
 export function RadarChart({
   ratings,
   locale,
@@ -36,6 +59,9 @@ export function RadarChart({
   const values = ratings.map((r) => r.value);
   const labels = AXES.map((a) => t(`axis.${a}` as MessageKey));
   const geo = radarGeometry(values, labels, size);
+
+  /** O eixo mais forte é o único rotulado por destaque — rótulo seletivo, não em todo ponto. */
+  const peak = values.reduce((best, v, i) => (v > values[best] ? i : best), 0);
 
   const dimmed = (i: number) => active !== null && active !== i;
 
@@ -64,13 +90,13 @@ export function RadarChart({
             />
           )}
 
-          {geo.sectors.map((sector, i) => (
+          {geo.axes.map((end, i) => (
             <line
               key={i}
               x1={geo.center}
               y1={geo.center}
-              x2={geo.vertices[i].x}
-              y2={geo.vertices[i].y}
+              x2={end.x}
+              y2={end.y}
               className="radar-spoke"
             />
           ))}
@@ -84,12 +110,19 @@ export function RadarChart({
             }}
           />
 
+          {/*
+            Anel de 2px na cor da superfície em volta de cada vértice. Não é
+            contorno decorativo: onde o vértice cai em cima da linha do polígono
+            ou de um raio da grade, sem o anel ele vira um engrossamento da linha
+            em vez de um ponto. O anel é o separador, e é a cor do fundo que
+            separa — nunca uma borda desenhada.
+          */}
           {geo.vertices.map((v, i) => (
             <circle
               key={i}
               cx={v.x}
               cy={v.y}
-              r={active === i ? 4 : 3.5}
+              r={active === i ? 4.5 : 4}
               className="radar-vertex"
               opacity={dimmed(i) ? 0.3 : 1}
               style={{ transition: "r .2s ease, opacity .25s ease" }}
@@ -101,7 +134,7 @@ export function RadarChart({
               key={i}
               x={l.x}
               y={l.y}
-              textAnchor="middle"
+              textAnchor={l.anchor}
               dominantBaseline="middle"
               className="radar-label"
               fill={active === i ? "var(--text)" : "var(--text-faint)"}
@@ -112,36 +145,66 @@ export function RadarChart({
             </text>
           ))}
 
-          {AXES.map((_, i) => (
+          {/*
+            O setor inteiro é o alvo, e não o vértice de 8px: mirar num ponto
+            desse tamanho é exigir pontaria. `tabIndex` porque hover não pode ser
+            o único jeito de chegar no destaque — teclado mostra o mesmo que o
+            mouse.
+          */}
+          {AXES.map((axis, i) => (
             <polygon
               key={i}
               points={radarSector(geo.center, geo.radius + 17, i, AXES.length)}
               fill="transparent"
               className="radar-hitzone"
+              tabIndex={0}
+              role="button"
+              aria-label={`${labels[i]}: ${formatRaw(ratings[i].raw, locale)}`}
               onMouseEnter={() => setActive(i)}
               onMouseLeave={() => setActive(null)}
+              onFocus={() => setActive(i)}
+              onBlur={() => setActive(null)}
               onClick={() => setActive((prev) => (prev === i ? null : i))}
             />
           ))}
         </svg>
-
-        {active !== null && (
-          <div className="radar-tooltip">
-            <div className="radar-tooltip-label">{labels[active]}</div>
-            <div className="radar-tooltip-value">
-              {ratings[active].raw.toLocaleString(locale)}
-            </div>
-          </div>
-        )}
       </div>
 
-      <table className="visually-hidden">
-        <caption>{t("radar.title")}</caption>
+      {/*
+        A tabela que era escondida, agora visível. Mesma marcação semântica de
+        antes — `<th scope="row">` por eixo — então o leitor de tela não perdeu
+        nada; quem enxerga é que ganhou o número sem precisar de mouse.
+      */}
+      <table className="radar-values">
+        <caption>
+          {t("radar.values")} <span>{t("radar.normalized")}</span>
+        </caption>
         <tbody>
-          {ratings.map((rating) => (
-            <tr key={rating.axis}>
+          {ratings.map((rating, i) => (
+            <tr
+              key={rating.axis}
+              data-active={active === i || undefined}
+              data-peak={i === peak || undefined}
+              data-dim={dimmed(i) || undefined}
+              onMouseEnter={() => setActive(i)}
+              onMouseLeave={() => setActive(null)}
+            >
               <th scope="row">{t(`axis.${rating.axis}` as MessageKey)}</th>
-              <td>{rating.raw.toLocaleString(locale)}</td>
+              <td className="radar-meter-cell">
+                {/*
+                  A barra é redundante com o número ao lado, de propósito: o
+                  número diz quanto, a barra diz quanto **comparado aos outros
+                  quatro eixos** — que é a leitura que o radar dá de relance e
+                  que uma coluna de números sozinha não dá.
+                */}
+                <span className="radar-meter" aria-hidden="true">
+                  <span
+                    className="radar-meter-fill"
+                    style={{ width: `${Math.max(2, rating.value)}%` }}
+                  />
+                </span>
+              </td>
+              <td className="radar-raw">{formatRaw(rating.raw, locale)}</td>
             </tr>
           ))}
         </tbody>

--- a/lib/i18n/dictionaries.ts
+++ b/lib/i18n/dictionaries.ts
@@ -113,6 +113,9 @@ const pt = {
 
   "radar.title": "Assinatura do perfil",
   "radar.caption": "Forma comparativa, não medição — os números exatos estão ao lado.",
+  "radar.axis": "Eixo",
+  "radar.values": "Valores por eixo",
+  "radar.normalized": "índice 0–99, escala logarítmica",
   "axis.reach": "Alcance",
   "axis.community": "Comunidade",
   "axis.volume": "Volume",
@@ -181,6 +184,10 @@ const pt = {
   "battle.skip": "Pular animação",
   "battle.radar": "Assinatura do perfil",
   "battle.radarCaption": "Sobreposição dos dois oponentes",
+  "battle.axisCompare": "Comparação por eixo",
+  "battle.lead": "vantagem",
+  "battle.tie": "empate",
+  "battle.hpLeft": "PS restantes",
 } as const;
 
 export type MessageKey = keyof typeof pt;
@@ -268,6 +275,9 @@ const en: Record<MessageKey, string> = {
 
   "radar.title": "Profile signature",
   "radar.caption": "Comparative shape, not measurement — exact numbers are alongside.",
+  "radar.axis": "Axis",
+  "radar.values": "Values by axis",
+  "radar.normalized": "0–99 index, logarithmic scale",
   "axis.reach": "Reach",
   "axis.community": "Community",
   "axis.volume": "Volume",
@@ -332,6 +342,10 @@ const en: Record<MessageKey, string> = {
   "battle.skip": "Skip animation",
   "battle.radar": "Profile signature",
   "battle.radarCaption": "Both opponents overlaid",
+  "battle.axisCompare": "Axis by axis",
+  "battle.lead": "lead",
+  "battle.tie": "tie",
+  "battle.hpLeft": "HP left",
 };
 
 const DICTIONARIES: Record<Locale, Record<MessageKey, string>> = { pt, en };

--- a/lib/radar.ts
+++ b/lib/radar.ts
@@ -16,6 +16,19 @@ export interface RadarVertex {
 
 export interface RadarLabel extends RadarVertex {
   label: string;
+  /**
+   * `text-anchor` do rótulo.
+   *
+   * Ancorar tudo em `middle` centraliza o texto **sobre o ponto do eixo**, e o
+   * ponto do eixo está a poucos pixels da grade: um rótulo longo num eixo
+   * lateral cresce metade para fora e metade para dentro, e a metade de dentro
+   * cai em cima do polígono ("COMUNIDADE" encostava na aresta). Com `start` à
+   * direita e `end` à esquerda, o texto cresce sempre para fora.
+   *
+   * `middle` fica só para os eixos perto da vertical, onde não há lado de fora
+   * horizontal para onde crescer.
+   */
+  anchor: "start" | "middle" | "end";
 }
 
 export interface RadarGeometry {
@@ -23,6 +36,14 @@ export interface RadarGeometry {
   radius: number;
   /** Corners of the data polygon, one per axis. */
   vertices: RadarVertex[];
+  /**
+   * Outer end of each axis, at the full radius — where the spokes stop.
+   *
+   * Separate from `vertices` because the grid is structure, not data: a spoke
+   * that stops at the data point makes the grid change shape with the profile,
+   * and the rings (always drawn full) stop agreeing with it.
+   */
+  axes: RadarVertex[];
   /** SVG `points` attribute for the data polygon. */
   points: string;
   /** Concentric polygon outlines at the given fractions of the radius. */
@@ -99,12 +120,23 @@ export function radarGeometry(
     center,
     radius,
     vertices,
+    axes: Array.from({ length: sides }, (_, i) => at(center, radius, i, sides)),
     points: vertices.map((v) => `${v.x},${v.y}`).join(" "),
     rings: RING_FRACTIONS.map((f) => polygonPoints(sides, radius * f, center)),
     sectors: Array.from({ length: sides }, (_, i) => radarSector(center, radius, i, sides)),
-    labels: labels.map((label, i) => ({
-      label,
-      ...at(center, radius + size * LABEL_GAP_SHARE, i, sides),
-    })),
+    labels: labels.map((label, i) => {
+      const cos = Math.cos(angleFor(i, sides));
+      return {
+        label,
+        // 0.3 é o mesmo corte que `labelPosition` já usava: abaixo dele o eixo
+        // está perto o bastante da vertical para o texto centrado não invadir
+        // nada de lado.
+        anchor: (Math.abs(cos) < 0.3 ? "middle" : cos > 0 ? "start" : "end") as
+          | "start"
+          | "middle"
+          | "end",
+        ...at(center, radius + size * LABEL_GAP_SHARE, i, sides),
+      };
+    }),
   };
 }

--- a/lib/viz/series.ts
+++ b/lib/viz/series.ts
@@ -1,0 +1,77 @@
+/**
+ * Cor de **série** dos gráficos comparativos. Não é a cor do tipo.
+ *
+ * A distinção é a correção mais importante deste módulo, então vale escrever por
+ * inteiro por que ela existe.
+ *
+ * `lib/cards/palette.json` dá a cada tipo uma cor extraída do ícone dele. Isso é
+ * ótimo como **identidade de carta** — a moldura, a auréola, o disco do tipo — e
+ * inútil como **identidade de série** num gráfico de dois oponentes, porque as 18
+ * cores nunca foram escolhidas para serem distinguíveis entre si. Rodando
+ * `scripts/validate_palette.js` da skill de dataviz contra a superfície escura
+ * (`--bg-raised`, #161a22), confrontos reais falham assim:
+ *
+ * | Confronto              | ΔE visão normal | ΔE pior CVD |
+ * |------------------------|-----------------|-------------|
+ * | electric × electric    | **0,0**         | **0,0**     |
+ * | steel × flying         | **2,0**         | **1,9**     |
+ * | electric × bug         | **12,9**        | 10,7        |
+ * | fire × grass           | 26,5            | **6,1**     |
+ *
+ * O piso é ΔE ≥ 15 na visão normal e ≥ 8 sob daltonismo. Três dos quatro casos
+ * acima são reprovação dura, e o primeiro é o mais comum de todos: dois devs de
+ * JavaScript são os dois `electric`, e o radar desenhava dois polígonos da
+ * **mesma cor**, com duas bolinhas idênticas na legenda. Não há encoding
+ * secundário que conserte ΔE 0 — a única saída é não pintar série por tipo.
+ *
+ * Então a batalha ganha dois slots fixos, azul e laranja, validados nas duas
+ * superfícies do site (#161a22 e #0d0f14): ΔE 29,2 na visão normal e 23,9 no pior
+ * caso de daltonismo, dentro da faixa de luminosidade e acima de 3:1 de
+ * contraste. Azul e laranja são o par quente/frio clássico justamente porque
+ * sobrevive a protanopia e deuteranopia, onde vermelho×verde colapsa.
+ *
+ * O tipo não some da tela: ele continua no `TypeIcon` ao lado de cada nome, que
+ * é onde ele é identidade e não codificação. E a cor segue o **lado**, nunca o
+ * ranking — quem está em `a` é azul do começo ao fim da página, ganhando ou
+ * perdendo.
+ */
+
+import type { Side } from "@/lib/battle/types";
+
+export const SIDE_COLORS: Record<Side, string> = {
+  a: "#3A8AD8",
+  b: "#D96E2C",
+};
+
+/**
+ * Forma do marcador de cada lado — o encoding secundário.
+ *
+ * Cor validada resolve o caso de daltonismo, mas não o de impressão em cinza nem
+ * o de `forced-colors`. Duas formas diferentes de vértice resolvem os três de uma
+ * vez e não custam nada: identidade nunca depende só de matiz.
+ *
+ * Círculo e losango, e não círculo e quadrado: no radar os vértices caem em
+ * ângulos arbitrários, e um quadrado de lado reto lê como círculo mal desenhado
+ * quando é pequeno. O losango tem ponta, que se reconhece a 8px.
+ */
+export type MarkerShape = "circle" | "diamond";
+
+export const SIDE_MARKERS: Record<Side, MarkerShape> = {
+  a: "circle",
+  b: "diamond",
+};
+
+/**
+ * Caminho SVG de um marcador centrado em (x, y).
+ *
+ * `r` é o raio do círculo circunscrito, para as duas formas ocuparem a mesma
+ * área ótica — um losango inscrito no mesmo raio parece menor que o círculo, e
+ * por isso ele ganha 15% a mais.
+ */
+export function markerPath(shape: MarkerShape, x: number, y: number, r: number): string {
+  if (shape === "circle") {
+    return `M ${x - r} ${y} a ${r} ${r} 0 1 0 ${r * 2} 0 a ${r} ${r} 0 1 0 ${-r * 2} 0 Z`;
+  }
+  const d = r * 1.15;
+  return `M ${x} ${y - d} L ${x + d} ${y} L ${x} ${y + d} L ${x - d} ${y} Z`;
+}


### PR DESCRIPTION
## O problema que motivou tudo

A cor do tipo não serve como identidade de série num gráfico de dois oponentes. Rodando o validador de paleta (`dataviz/scripts/validate_palette.js`) contra a superfície escura do site (`--bg-raised`, `#161a22`), confrontos reais reprovam:

| Confronto | ΔE visão normal | ΔE pior CVD |
|---|---|---|
| `electric` × `electric` | **0,0** | **0,0** |
| `steel` × `flying` | **2,0** | **1,9** |
| `electric` × `bug` | **12,9** | 10,7 |
| `fire` × `grass` | 26,5 | **6,1** |

O piso é ΔE ≥ 15 na visão normal e ≥ 8 sob daltonismo. Três dos quatro reprovam, e o primeiro é o caso **mais comum de todos**: dois devs de JavaScript são os dois `electric`, e o radar de batalha desenhava **dois polígonos da mesma cor, com duas bolinhas idênticas na legenda**. As barras de PS tinham a mesma colisão. Não existe encoding secundário que conserte ΔE 0,0.

As 18 cores de `palette.json` nunca foram escolhidas para serem distinguíveis entre si — elas foram extraídas do disco de cada ícone. São ótimas como identidade de carta e inúteis como identidade de série.

## A correção

`lib/viz/series.ts` dá dois slots fixos à batalha — azul `#3A8AD8` e laranja `#D96E2C`. Validados nas duas superfícies do site: **ΔE 29,2 na visão normal e 23,9 no pior caso de daltonismo**, dentro da faixa de luminosidade e acima de 3:1 de contraste. Quente/frio é o par que sobrevive a protanopia e deuteranopia, onde vermelho×verde colapsa.

Vértice **círculo × losango** como segunda pista, para a identidade sobreviver a impressão em cinza e a `forced-colors`. O tipo não some da tela: continua no disco ao lado de cada nome, que é onde ele é identidade e não codificação. E a cor segue o **lado**, nunca o ranking — quem está em `a` é azul do começo ao fim da página, ganhando ou perdendo.

## Os números saíram do hover

Os dois radares gateavam todo valor atrás da posição do mouse. Tooltip complementa, nunca é o único caminho para o dado.

- **Carta:** a `<table class="visually-hidden">` virou visível — uma barra por eixo mais o número cru ao lado. Espelhada na coluna esquerda via `direction`, sem mexer na ordem do DOM (o leitor de tela continua ouvindo rótulo → barra → valor).
- **Batalha:** tabela nova de comparação eixo a eixo — dois pontos numa régua só, ligados por um traço cujo comprimento **é** a vantagem. O radar mostra *que* os perfis diferem; ele é ruim para dizer *quanto*, porque comparar duas áreas irregulares a olho não funciona e nos eixos empatados os polígonos se encavalam.

Os números da tabela de batalha são o índice 0–99, e não a métrica crua, porque é o índice que os pontos desenham — imprimir "254.470 estrelas" ao lado de um ponto posicionado por `log(254.470)` seria uma legenda que discorda do próprio gráfico. A legenda diz o que o índice é.

## Também

- **Rótulo de eixo** ancora `start`/`end` nos eixos laterais. Com tudo em `middle`, "COMUNIDADE" crescia metade para dentro e encostava no polígono.
- **Raios da grade** vão até o raio cheio (`geo.axes`). Parando no vértice do dado, a grade mudava de forma junto com o perfil e parava de bater com os anéis, que sempre foram desenhados inteiros.
- **Anel de 2px da superfície** nos vértices e nos pontos da régua. Quem separa marca sobreposta é o fundo, nunca uma borda desenhada em volta dela.
- **Medidor de PS** com trilho num passo mais claro da própria cor do lado, ponta arredondada no dado, e **rastro do golpe** — sem ele, um dano de 10 e um de 60 têm a mesma aparência, porque a barra encolhe nos dois casos e o que mudou já passou quando o olho chega.
- **Trilho e marcador do atacante** em cada linha do log. Era a única parte da página onde os dois lados se alternam na mesma coluna, e sem marca de autoria era preciso ler o nome até o fim para saber de quem era o turno.
- **Setores do radar acessíveis por teclado** (`tabIndex` + `focus-visible`); antes só havia `onMouseEnter`, e `outline: none` tirava até a prova de foco.
- Preenchimento dos polígonos de batalha caiu de 28% para 16%: são duas áreas que se cruzam, e a 28% cada o miolo virava bloco chapado justamente onde a comparação acontece.

## Dois bugs encontrados no caminho

- **`<ol className="replay-log">` não tinha o `ref={logRef}`** — o `useEffect` de auto-scroll lia `logRef.current`, achava `null` e voltava. O auto-scroll do log nunca rodou desde que foi escrito.
- **Veterania mostrava `14,945`** (a fração crua de `yearsSince`) ao lado de `254.470` e `316.307`. Em pt-BR isso lê como quatorze mil. Agora `Math.floor`, exatamente como `profile.ts` já fazia na linha de recuo — o comentário lá já dizia que "14,937808668117981 anos" não é dado, é vazamento de implementação. Enquanto o valor vivia escondido no tooltip dava para não reparar.

## Verificação

- `npm run typecheck` — limpo
- `npm test` — 155/155
- `npm run build` — passa
- As duas views conferidas no navegador contra o build de produção, sem erro de console
