### PR TITLE
fix(e2e): sonda a proteção da Vercel antes da suíte, e agrupa as majors de lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,14 @@
 version: 2
 
+# O que este arquivo NÃO resolve, e é bom deixar escrito: em 14/08/2026 as PRs
+# #11 (eslint 10) e #12 (typescript 7) entraram em `main` com o job `quality`
+# vermelho. O gate tinha acusado as duas quebras — não havia proteção de branch
+# exigindo que ele passasse. Nenhum agrupamento conserta merge por cima de CI
+# vermelho; quem conserta é exigir `quality` em Settings > Branches.
+#
+# O que está aqui embaixo é o segundo nível: diminuir a chance de uma major
+# chegar sozinha e parecer inofensiva.
+
 updates:
   # Patch e minor chegam num PR só; major do framework vem separado, porque é
   # trabalho de verdade e não deve viajar de carona com atualização de rotina.
@@ -11,9 +20,37 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+
+    ignore:
+      # `@types/node` descreve a API de um runtime, e o runtime aqui é o do
+      # `.nvmrc` — Node 22. Tipar contra o 26 libera chamada que não existe em
+      # produção sem o `tsc` reclamar, porque para ele passa a existir. Quando o
+      # `.nvmrc` subir, esta regra sobe junto; não é para ficar para sempre.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+
     groups:
       framework:
         patterns: ["next", "react", "react-dom", "@types/react", "@types/react-dom"]
+
+      # eslint e typescript não têm major própria: quem decide se ela passa é o
+      # `eslint-config-next` e o `typescript-eslint` que ele embute. Foi
+      # exatamente assim que as duas quebraram — o typescript-eslint recusa a TS
+      # 7 por design, e o `eslint-plugin-react` de dentro do config-next chama
+      # uma API que o ESLint 10 removeu. Separadas, cada PR parecia um bump de
+      # rotina. Juntas, ou o conjunto passa no gate ou nenhuma entra.
+      #
+      # Vem antes de `dev` de propósito: a primeira regra que casa é a que vale,
+      # e `dev` engoliria estas se viesse primeiro.
+      ferramental-lint:
+        patterns:
+          - "eslint"
+          - "eslint-config-next"
+          - "typescript"
+          - "typescript-eslint"
+          - "@typescript-eslint/*"
+        update-types: ["major", "minor", "patch"]
+
       dev:
         dependency-type: development
         update-types: ["minor", "patch"]

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,6 +21,10 @@ import { defineConfig, devices } from "@playwright/test";
  * os testes falham de um jeito que não parece proteção — parece bug. O
  * `set-bypass-cookie` não é redundante com o header: sem o cookie, os `page.goto`
  * passariam pelo header no documento e esbarrariam na proteção nos subrecursos.
+ *
+ * Estes headers resolvem o caso em que o secret existe. Quando ele falta, quem
+ * fala é o `globalSetup`: mandar a suíte inteira contra a tela de login produz
+ * vinte falhas que acusam as rotas de imagem, e nenhuma que acuse a proteção.
  */
 const bypass = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
 const protectionHeaders = bypass
@@ -29,8 +33,10 @@ const protectionHeaders = bypass
       "x-vercel-set-bypass-cookie": "true",
     }
   : undefined;
+
 export default defineConfig({
   testDir: "./tests/e2e",
+  globalSetup: "./tests/e2e/global-setup.ts",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,80 @@
+/**
+ * Sonda o deployment antes da primeira suíte, para que a Deployment Protection
+ * da Vercel falhe como proteção e não como bug.
+ *
+ * ## O que acontecia sem isto
+ *
+ * Protegido, o deployment responde `302` para `vercel.com/sso-api`. O Playwright
+ * segue o redirect, cai na tela de login e recebe dela um `200 text/html`. O
+ * `expect(status).toBe(200)` passa, o `content-type` estoura, e o relatório diz
+ * que a rota de imagem devolveu HTML — que é exatamente o sintoma de uma rota
+ * quebrada. Vinte testes falham assim, depois de sete minutos de execução, e
+ * nada na saída menciona proteção.
+ *
+ * A sonda troca isso por uma linha, em segundos, dizendo qual secret falta.
+ *
+ * ## Por que sondar em vez de exigir o secret
+ *
+ * Exigir `VERCEL_AUTOMATION_BYPASS_SECRET` sempre que houver `E2E_BASE_URL`
+ * seria mais curto e estaria errado: quem desliga a Deployment Protection não
+ * precisa de bypass nenhum, e passaria a ser barrado por um gate inventado
+ * aqui. Quem responde se o runner entra é o próprio deployment, então é ele que
+ * decide.
+ */
+
+const SSO = "vercel.com/sso-api";
+
+export default async function globalSetup() {
+  const baseUrl = process.env.E2E_BASE_URL;
+
+  // Sem a variável o alvo é o `next dev` do `webServer`, que não tem proteção.
+  if (!baseUrl) return;
+
+  const bypass = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+
+  /*
+   * `redirect: "manual"` é o ponto: seguindo o redirect chegaríamos ao mesmo
+   * `200 text/html` que engana os testes. O que interessa é o salto, não o
+   * destino.
+   */
+  const response = await fetch(baseUrl, {
+    redirect: "manual",
+    headers: bypass
+      ? {
+          "x-vercel-protection-bypass": bypass,
+          "x-vercel-set-bypass-cookie": "true",
+        }
+      : {},
+  });
+
+  const location = response.headers.get("location") ?? "";
+  if (!location.includes(SSO)) return;
+
+  /*
+   * Duas causas, uma mensagem cada: sem o secret é configuração que falta, com
+   * o secret é valor errado ou vencido. Trocar um pelo outro custa a tarde de
+   * quem for atrás.
+   */
+  const diagnostico = bypass
+    ? [
+        "O secret VERCEL_AUTOMATION_BYPASS_SECRET está definido, mas o deployment",
+        "não o aceitou — valor errado, ou regerado na Vercel depois de gravado aqui.",
+      ]
+    : [
+        "Falta o secret VERCEL_AUTOMATION_BYPASS_SECRET.",
+        "Na Vercel: Project Settings > Deployment Protection > Protection Bypass for",
+        "Automation. Copie o valor para Settings > Secrets and variables > Actions,",
+        "no GitHub, com esse mesmo nome.",
+      ];
+
+  throw new Error(
+    [
+      `A Deployment Protection da Vercel está barrando o runner em ${baseUrl}.`,
+      "",
+      ...diagnostico,
+      "",
+      "Alternativa: desligar a Deployment Protection para Preview, e aí nenhum",
+      "secret é necessário — ao custo de o preview ficar público.",
+    ].join("\n"),
+  );
+}


### PR DESCRIPTION
Duas coisas na mesma PR porque a investigação foi a mesma: o `e2e` e o Dependabot falharam pelo mesmo motivo de fundo — o CI disse a verdade e ninguém foi obrigado a ouvir.

## 1. e2e — a falha mentia sobre a causa

Protegido, o deployment responde `302` para `vercel.com/sso-api`:

```
$ curl -sI https://<preview>.vercel.app/torvalds.png
HTTP/2 302
location: https://vercel.com/sso-api?url=...&nonce=...
set-cookie: _vercel_sso_nonce=...
```

O Playwright segue o redirect, cai na tela de login e recebe **dela** um `200 text/html`. Por isso o relatório dizia isto:

```
  15 |     expect(response.status()).toBe(200);        <- passa
> 16 |     expect(response.headers()["content-type"]).toBe("image/png");
       Received: "text/html; charset=utf-8"
```

Ou seja: acusava a rota de imagem por devolver HTML, que é exatamente o sintoma de uma rota quebrada. Vinte testes falhando assim, 7min43 depois, e nada na saída mencionando proteção. O comentário do `playwright.config.ts` já dizia que isso aconteceria — "não parece proteção, parece bug" — mas o código não agia sobre isso.

Agora um `globalSetup` sonda a base antes da primeira suíte:

```
Error: A Deployment Protection da Vercel está barrando o runner em https://<preview>.vercel.app.

Falta o secret VERCEL_AUTOMATION_BYPASS_SECRET.
Na Vercel: Project Settings > Deployment Protection > Protection Bypass for
Automation. Copie o valor para Settings > Secrets and variables > Actions,
no GitHub, com esse mesmo nome.

Alternativa: desligar a Deployment Protection para Preview, e aí nenhum
secret é necessário — ao custo de o preview ficar público.
```

Mensagem diferente para secret ausente e para secret recusado: trocar uma causa pela outra custa a tarde de quem for atrás.

**Sondar em vez de exigir o secret** quando há `E2E_BASE_URL`: quem desliga a Deployment Protection não precisa de bypass nenhum e seria barrado por um gate inventado aqui. Quem responde se o runner entra é o próprio deployment.

Testado nos três caminhos, contra o preview real:

| cenário | resultado |
|---|---|
| protegido, sem secret | erro de configuração, em segundos |
| protegido, secret errado | erro de valor recusado |
| alvo sem proteção | passa direto, os 20 testes rodam |

> ⚠️ **Isto não faz o `e2e` ficar verde.** Falta o *valor* do secret, e só quem tem acesso à Vercel grava. Esta PR faz a falha dizer isso em vez de apontar para o lugar errado.

## 2. Dependabot — o agrupamento não era o problema

O que aconteceu em 14/08:

| PR | `quality` | mergeada |
|---|---|---|
| #11 eslint 9→10 | **FAILURE** | 15:09 |
| #12 typescript 5.9→7 | **FAILURE** | 15:11 |

O gate acusou as duas quebras, corretamente, antes do merge. `main` não tem proteção de branch nenhuma (`gh api .../branches/main/protection` → 404, e `rulesets` → `[]`), então nada exigiu que ele passasse.

**O melhor caminho para o Dependabot é, em primeiro lugar, exigir `quality` em `main`.** Nenhum agrupamento, ignore ou schedule conserta merge por cima de CI vermelho. Deixei isso escrito no topo do `dependabot.yml` para o arquivo não parecer que resolve o que não resolve.

Vale junto o *require branches to be up to date*: as #13 e #14 tinham verde de 13:56, mais de uma hora antes de #11 e #12 entrarem. Verde velho parece verde.

Em segundo lugar, e é o que esta PR faz:

**`ferramental-lint`** — `eslint`, `typescript`, `eslint-config-next` e `typescript-eslint` passam a andar juntos, majors inclusive. É a lição literal de hoje: o typescript-eslint recusa a TS 7 por design e o `eslint-plugin-react` de dentro do config-next chama uma API que o ESLint 10 removeu. Separadas, cada PR parecia bump de rotina. Juntas, ou o conjunto passa no gate ou nenhuma entra.

**`@types/node`** — major ignorada. Ela descreve a API de um runtime, e o runtime é o do `.nvmrc` (Node 22). Tipar contra o 26 libera chamada que não existe em produção sem o `tsc` reclamar, porque para ele passa a existir. Quando o `.nvmrc` subir, a regra sobe junto — está comentado que não é para ficar para sempre. Efeito colateral: a **#14** deve ser fechada pelo próprio Dependabot no próximo ciclo.

## Verificação

```
npm run lint       limpo
npm run typecheck  limpo
npm test           155 testes, 12 arquivos
```
