### PR TITLE
ci: não reprova PR de fork, e nomeia o ambiente que falta antes do deploy

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,6 +4,23 @@
 # é isso que este workflow explora: os testes batem no ambiente serverless real —
 # com Redis, com os rewrites de `next.config.ts` valendo — em vez de num
 # `next dev`. Nenhum teste precisou mudar para isso.
+#
+# ## PR vindo de fork
+#
+# O GitHub não entrega secrets para workflow disparado por fork, e é a decisão
+# certa: o PR traz código que ninguém revisou ainda. A consequência aqui é que
+# `deploy`, `e2e` e `comment` não têm como funcionar — sem `VERCEL_TOKEN` o
+# primeiro passo do deploy morre, e sem `pull-requests: write` o comentário
+# também.
+#
+# Sem o gate de origem abaixo, isso vira um PR vermelho na cara de quem
+# contribuiu de fora pela primeira vez, por um motivo que não é dele e que ele
+# não tem como resolver. `quality` não usa secret nenhum, então roda sempre: é
+# ele que responde a pergunta que o contribuidor de fato fez — lint, typecheck e
+# os testes passam?
+#
+# O preview de um PR de fork continua possível quando alguém quiser: o
+# mantenedor puxa a branch para o repositório e abre o PR de lá.
 name: preview
 
 on:
@@ -25,11 +42,14 @@ env:
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
 jobs:
+  # Sem `if`: é o gate que vale para todo mundo, e o único que roda em PR de
+  # fork. Ver o cabeçalho.
   quality:
     uses: ./.github/workflows/quality.yml
 
   deploy:
     needs: quality
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       url: ${{ steps.deploy.outputs.url }}
@@ -81,6 +101,32 @@ jobs:
       - name: Puxar o ambiente de Preview
         run: vercel pull --yes --environment=preview
 
+      # O `pull` acabou de escrever o ambiente resolvido em disco; conferir aqui
+      # é a última chance de nomear uma variável ausente antes que ela vire
+      # sintoma. Sem `GITHUB_TOKEN` o deploy sobe inteiro, e a rota de carta
+      # responde a carta de erro — um PNG de verdade, com texto dizendo que falta
+      # token. O e2e falha no `expect(status).toBe(200)` e acusa a rota, que está
+      # certa. Perde-se o deploy inteiro para descobrir isso.
+      #
+      # `REDIS_URL` é aviso e não erro: sem ele o preview funciona, só sai sem
+      # número de série e gastando mais rate limit (ver .env.example).
+      - name: Conferir o ambiente de Preview
+        run: |
+          env_file=".vercel/.env.preview.local"
+          if [ ! -f "$env_file" ]; then
+            echo "::error::$env_file não existe — o vercel pull não escreveu o ambiente."
+            exit 1
+          fi
+
+          if ! grep -q '^GITHUB_TOKEN=..' "$env_file"; then
+            echo "::error::GITHUB_TOKEN não está definido no ambiente Preview da Vercel. Toda carta do preview vai sair como carta de erro e o e2e vai falhar acusando as rotas de imagem. Grave em Vercel > Project Settings > Environment Variables, marcando Preview."
+            exit 1
+          fi
+
+          if ! grep -q '^REDIS_URL=..' "$env_file"; then
+            echo "::warning::REDIS_URL não está definido no ambiente Preview. O preview funciona, mas as cartas saem sem número de série e o cache cai para o fallback por processo."
+          fi
+
       # `vercel build` resolve o `outputFileTracingIncludes` de next.config.ts
       # aqui, no runner — é o que faz `public/assets/**` chegar nas funções de
       # imagem. O `--prebuilt` do passo seguinte sobe exatamente este output.
@@ -91,6 +137,9 @@ jobs:
         id: deploy
         run: echo "url=$(vercel deploy --prebuilt)" >> "$GITHUB_OUTPUT"
 
+  # Sem `if` de origem aqui, e não é esquecimento: job cuja dependência foi
+  # pulada é pulado junto. Repetir a condição em cada job daria a impressão de
+  # que ela é o que segura o e2e, quando quem segura é o `needs`.
   e2e:
     needs: deploy
     runs-on: ubuntu-latest
@@ -123,9 +172,23 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
+  # Diz em voz alta o que foi pulado, para quem abriu o PR de fora. Um job
+  # ausente da lista de checks é indistinguível de um job que ninguém escreveu:
+  # sem isto, o contribuidor fica esperando um preview que não vem.
+  aviso-de-fork:
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Por que não há preview neste PR
+        run: |
+          echo "::notice title=Preview skipped for fork PR::Deploy and e2e need repository secrets, which GitHub does not share with forks. The quality gate (lint, typecheck, unit tests) ran and is the check that matters for review. A maintainer can produce a preview by pushing this branch to the repository."
+
   # "O que quebra em layout só quebra olhando" (README). O e2e verde não fecha
   # essa lacuna — este comentário é o que coloca a página renderizada a um clique
   # de quem revisa.
+  #
+  # `always()` faz este job rodar mesmo com `deploy` pulado; quem o desliga em PR
+  # de fork é o `needs.deploy.result == 'success'`, que não vale para `skipped`.
   comment:
     needs: [deploy, e2e]
     if: always() && needs.deploy.result == 'success'

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -71,6 +71,34 @@ jobs:
       - name: Puxar o ambiente de Production
         run: vercel pull --yes --environment=production
 
+      # Os dois pesam diferente, e o passo trata cada um como o código trata.
+      #
+      # `GITHUB_TOKEN` é fatal: sem ele **toda** carta vira carta de erro, e o
+      # deploy sobe verde servindo um produto que não funciona.
+      #
+      # `REDIS_URL` é aviso. A tentação é exigir, já que a RFC 11 o chama de
+      # obrigatório em produção, mas o código discorda por escrito: sem Redis a
+      # carta sai sem número de série, e `.env.example` argumenta que carta sem
+      # número é honesta enquanto carta com número errado, já embutida no README
+      # de alguém, não é. Degradar assim é a decisão de projeto — bloquear o
+      # deploy aqui seria endurecê-la por conta própria.
+      - name: Conferir o ambiente de Production
+        run: |
+          env_file=".vercel/.env.production.local"
+          if [ ! -f "$env_file" ]; then
+            echo "::error::$env_file não existe — o vercel pull não escreveu o ambiente."
+            exit 1
+          fi
+
+          if ! grep -q '^GITHUB_TOKEN=..' "$env_file"; then
+            echo "::error::GITHUB_TOKEN não está definido no ambiente Production da Vercel. Toda carta serviria a carta de erro. Grave em Project Settings > Environment Variables."
+            exit 1
+          fi
+
+          if ! grep -q '^REDIS_URL=..' "$env_file"; then
+            echo "::warning::REDIS_URL não está definido em Production: as cartas vão sair sem número de série e o cache da API cai para o fallback por processo (RFC 11, .env.example)."
+          fi
+
       - name: Build
         run: vercel build --prod
 
@@ -78,13 +106,17 @@ jobs:
         id: deploy
         run: echo "url=$(vercel deploy --prebuilt --prod)" >> "$GITHUB_OUTPUT"
 
-  # Recorte deliberado: só o describe "rotas de imagem" de tests/e2e/smoke.spec.ts.
+  # Recorte deliberado: só o que está marcado `@smoke` em tests/e2e/smoke.spec.ts.
   #
   # São os casos que provam que produção está de fato ligada — PNG com o
   # Cache-Control da RFC 4.2, carta de repo, prévia em 1200x630, carta de erro
   # com max-age curto e o recorte de /assets/ no rewrite. Os demais ficam de
   # fora porque os testes de batalha gravariam registros reais no Redis de
   # produção, com TTL de 30 dias, a cada push em main.
+  #
+  # Era `-g "rotas de imagem"`, que casava pelo título do describe: renomear o
+  # describe desligava este smoke sem que nada apontasse para cá. A tag é
+  # declarada no teste, do lado de quem decide se ele escreve ou não.
   smoke:
     needs: deploy
     runs-on: ubuntu-latest
@@ -102,7 +134,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Smoke das rotas de imagem
-        run: npm run test:e2e -- -g "rotas de imagem"
+        run: npm run test:e2e -- --grep @smoke
         env:
           E2E_BASE_URL: ${{ needs.deploy.outputs.url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -8,7 +8,15 @@ function pngSize(buffer: Buffer): { width: number; height: number } {
   return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) };
 }
 
-test.describe("rotas de imagem", () => {
+/*
+ * `@smoke` é o recorte que `production.yml` roda contra o deployment recém-subido:
+ * os casos que provam que produção está de fato ligada, sem escrever nada.
+ *
+ * A tag existe porque o recorte era `-g "rotas de imagem"`, casando pelo título
+ * em português deste describe. Renomear o describe desligava o smoke de produção
+ * em silêncio, e nada nos dois lados do acoplamento dizia que ele existia.
+ */
+test.describe("rotas de imagem", { tag: "@smoke" }, () => {
   test("serve a carta de perfil em /<user>.png com o cache da RFC 4.2", async ({ request }) => {
     const response = await request.get("/torvalds.png");
 
@@ -256,7 +264,13 @@ test.describe("site", () => {
   });
 });
 
-test.describe("batalha", () => {
+/*
+ * `@stateful`: estes gravam. Cada execução cria um registro de batalha no Redis
+ * com `BATTLE_TTL_SECONDS` (30 dias), e é por isso que produção roda só `@smoke`
+ * — o motivo estava comentado em `production.yml`, do lado de lá do recorte, e
+ * agora está aqui, do lado que o causa.
+ */
+test.describe("batalha", { tag: "@stateful" }, () => {
   test("sorteia, redireciona para um resultado estável e serve o pôster", async ({
     page,
     request,


### PR DESCRIPTION
Fase 1 e 2 do plano. O objetivo das duas é o mesmo: o CI só deve ficar vermelho quando há motivo, e deve dizer qual.

## 1. Um PR de fork parava vermelho sem culpa de quem abriu

O GitHub não entrega secrets para workflow disparado por fork — decisão certa, o PR traz código que ninguém revisou. A consequência aqui era o passo "Conferir as credenciais da Vercel" matando o `deploy`, o `e2e` pulado e o bot sem `pull-requests: write` para comentar. Primeira contribuição de alguém de fora, PR vermelho, por um motivo que não é dele e que ele não tem como resolver.

```diff
   deploy:
     needs: quality
+    if: github.event.pull_request.head.repo.full_name == github.repository
```

`quality` fica sem condição: não usa secret nenhum e é ele que responde a pergunta que o contribuidor de fato fez — lint, typecheck e testes passam?

`e2e` e `comment` **não** ganharam `if`, e está comentado no arquivo para ninguém "consertar" depois: job cuja dependência foi pulada é pulado junto, e o `comment` já se desliga sozinho porque `needs.deploy.result == 'success'` não vale para `skipped`. Repetir a condição sugeriria que é ela quem os segura.

Um job novo, `aviso-de-fork`, escreve um `::notice::` explicando o pulo. Job ausente da lista de checks é indistinguível de job que ninguém escreveu — sem isso o contribuidor fica esperando um preview que não vem.

## 2. O recorte do smoke casava por título em português

`production.yml` recortava com `-g "rotas de imagem"`, o título do `describe`. Renomear o describe desligaria o smoke de produção, e nenhum dos dois lados do acoplamento dizia que ele existia.

```diff
-        run: npm run test:e2e -- -g "rotas de imagem"
+        run: npm run test:e2e -- --grep @smoke
```

As tags agora são declaradas no teste: `@smoke` no que só lê, `@stateful` na batalha — que grava um registro no Redis com TTL de 30 dias a cada execução. O motivo do recorte morava só no workflow; passa a morar também no teste que o causa.

Equivalência conferida antes e depois:

```
-g "rotas de imagem"   ->  5 testes
--grep @smoke          ->  5 testes   (os mesmos)
--grep @stateful       ->  2 testes
sem filtro             -> 20 testes   (inalterado)
```

## 3. O ambiente da Vercel está vazio, e isso apareceria como bug de rota

Fui verificar se Preview e Production dividem o mesmo Redis — item 2.2 do plano. A resposta é que **não existe Redis nenhum**. `vercel env ls` lista três variáveis no projeto inteiro:

| variável | ambiente |
|---|---|
| `NEXT_PUBLIC_BASE_URL` | Production |
| `GITHUB_TOKEN` | **Production** |
| `CARD_RATE_LIMIT_PER_WINDOW` | Preview |

Sem `REDIS_URL` em ambiente nenhum, e `vercel integration ls` não lista store.

**Preview não tem `GITHUB_TOKEN`.** Isso significa que toda carta do preview sai como carta de erro — um PNG de verdade, com texto — e o `e2e` falha no `expect(status).toBe(200)` acusando a rota de imagem, que está certa. É o próximo bloqueio depois do secret de bypass, e teria custado um deploy inteiro para descobrir.

O passo novo confere o ambiente logo depois do `vercel pull`, que acabou de escrever os valores resolvidos em disco:

| variável | Preview | Production |
|---|---|---|
| `GITHUB_TOKEN` | erro, para o deploy | erro, para o deploy |
| `REDIS_URL` | aviso | aviso |

`REDIS_URL` é aviso nos dois, e isso é deliberado. A tentação é exigir, já que a RFC 11 o chama de obrigatório em produção — mas o código discorda por escrito: sem Redis a carta sai sem número de série, e o `.env.example` argumenta que carta sem número é honesta enquanto carta com número errado, já embutida no README de alguém, não é. Bloquear o deploy nisso seria endurecer a decisão por conta própria.

## Verificação

```
npm run lint       limpo
npm run typecheck  limpo
npm test           155 testes
bash -n            todos os 20 blocos run dos workflows
js-yaml            preview.yml e production.yml parseiam
```

As condições de origem, lidas do YAML já parseado:

```
quality          (sem if)
deploy           head.repo.full_name == github.repository
e2e              (sem if — pulado pelo needs)
aviso-de-fork    head.repo.full_name != github.repository
comment          always() && needs.deploy.result == 'success'
```

**O que só dá para verificar de fora:** abrir um PR a partir de um fork de verdade e confirmar `quality` verde com o resto pulado. Não consigo simular isso de dentro do repositório.
