### PR TITLE
fix(e2e): testa produção no endereço público, e cobre o cache onde ele é visível

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -36,6 +36,7 @@ jobs:
       url: ${{ steps.deploy.outputs.url }}
     outputs:
       url: ${{ steps.deploy.outputs.url }}
+      public_url: ${{ steps.deploy.outputs.public_url }}
     steps:
       - uses: actions/checkout@v7
 
@@ -102,9 +103,36 @@ jobs:
       - name: Build
         run: vercel build --prod
 
+      # Duas URLs saem daqui, e o smoke precisa da segunda.
+      #
+      # `url` é o que o deploy imprime: a URL única daquele deployment
+      # (`gitmon-cards-<hash>-<escopo>.vercel.app`). Ela serve para o link do
+      # environment do GitHub, mas **está atrás da Deployment Protection** — a
+      # Standard Protection isenta o domínio de produção, não a URL de
+      # deployment. O smoke apontado para ela recebia o 302 para
+      # `vercel.com/sso-api` e falhava acusando as rotas de imagem.
+      #
+      # `public_url` é o alias estável de produção, tirado de
+      # NEXT_PUBLIC_BASE_URL, que é o mesmo endereço que vai dentro do README de
+      # terceiro. Testar produção em qualquer outro endereço é testar um lugar
+      # onde ninguém vai olhar.
       - name: Deploy
         id: deploy
-        run: echo "url=$(vercel deploy --prebuilt --prod)" >> "$GITHUB_OUTPUT"
+        run: |
+          url=$(vercel deploy --prebuilt --prod)
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+          # Avisa e cai para a URL de deployment em vez de derrubar o deploy: o
+          # produto já subiu quando esta linha roda, e perder o deploy por causa
+          # do endereço que o *teste* usa seria trocar um problema pequeno por um
+          # grande. Sem o alias o smoke falha como falhava antes, com a diferença
+          # de que agora o log diz por quê.
+          public_url=$(grep -m1 '^NEXT_PUBLIC_BASE_URL=' .vercel/.env.production.local 2>/dev/null | cut -d= -f2- | tr -d '"' || true)
+          if [ -z "$public_url" ]; then
+            echo "::warning::NEXT_PUBLIC_BASE_URL não veio no vercel pull; o smoke vai usar a URL de deployment, que está atrás da Deployment Protection e responde 302 para vercel.com/sso-api. Para corrigir, grave o endereço público como variável do repositório e leia-a aqui."
+            public_url="$url"
+          fi
+          echo "public_url=$public_url" >> "$GITHUB_OUTPUT"
 
   # Recorte deliberado: só o que está marcado `@smoke` em tests/e2e/smoke.spec.ts.
   #
@@ -133,11 +161,14 @@ jobs:
       - name: Instalar o Chromium
         run: npx playwright install --with-deps chromium
 
+      # O alias público, não a URL de deployment. Ver o comentário no passo de
+      # deploy. Sem bypass, de propósito: se o endereço que as pessoas embutem
+      # no README precisar de secret para responder, o produto está quebrado e é
+      # isto que tem que falhar.
       - name: Smoke das rotas de imagem
         run: npm run test:e2e -- --grep @smoke
         env:
-          E2E_BASE_URL: ${{ needs.deploy.outputs.url }}
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          E2E_BASE_URL: ${{ needs.deploy.outputs.public_url }}
 
       - uses: actions/upload-artifact@v7
         if: failure()

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -17,13 +17,45 @@ function pngSize(buffer: Buffer): { width: number; height: number } {
  * em silêncio, e nada nos dois lados do acoplamento dizia que ele existia.
  */
 test.describe("rotas de imagem", { tag: "@smoke" }, () => {
-  test("serve a carta de perfil em /<user>.png com o cache da RFC 4.2", async ({ request }) => {
+  test("serve a carta de perfil em /<user>.png", async ({ request }) => {
     const response = await request.get("/torvalds.png");
 
     expect(response.status()).toBe(200);
     expect(response.headers()["content-type"]).toBe("image/png");
-    expect(response.headers()["cache-control"]).toContain("s-maxage=86400");
+    // A janela do navegador é a única do header que sobrevive à CDN. Ver abaixo.
+    expect(response.headers()["cache-control"]).toContain("max-age=3600");
     expect((await response.body()).subarray(0, 8)).toEqual(PNG_MAGIC);
+  });
+
+  /*
+   * Este teste afirmava `s-maxage=86400` no header recebido, e falhava contra uma
+   * produção onde a política estava valendo.
+   *
+   * A Vercel **consome** `s-maxage` e `stale-while-revalidate` para o próprio
+   * cache de borda e não repassa nenhum dos dois ao cliente: a resposta chega
+   * como `public, max-age=3600`, com um `x-vercel-cache` ao lado. A asserção
+   * pedia para ver uma coisa que a plataforma esconde por construção — e o
+   * sintoma da falha (`Received: "public, max-age=3600"`) parecia com a rota
+   * servindo a política errada.
+   *
+   * A política em si passou a ser conferida onde é visível, em
+   * `tests/unit/cache-control.test.ts`, sobre a constante que a declara. Aqui
+   * fica o que só o e2e pode provar, e que aquele teste não alcança: que a borda
+   * de fato cacheou. Duas requisições, e a segunda tem que vir de lá.
+   */
+  test("é cacheada na borda, e não regerada a cada visita", async ({ request }) => {
+    test.skip(
+      !process.env.E2E_BASE_URL,
+      "só vale contra um deployment: o `next dev` não tem CDN na frente",
+    );
+
+    await request.get("/torvalds.png");
+    const segunda = await request.get("/torvalds.png");
+
+    // HIT ou STALE: os dois significam servido pela borda. Um MISS na segunda
+    // volta é o que este teste existe para pegar — carta regerada por visita
+    // esgota o rate limit do token e devolve a lentidão que o cache evita.
+    expect(segunda.headers()["x-vercel-cache"]).toMatch(/HIT|STALE/);
   });
 
   test("serve a carta de repositório em /<owner>/<repo>.png", async ({ request }) => {
@@ -283,6 +315,13 @@ test.describe("batalha", { tag: "@stateful" }, () => {
     const battleId = page.url().split("/").pop();
     const poster = await request.get(`/battle/${battleId}.png`);
 
+    /*
+     * Este 200 depende de `REDIS_URL`, e é a única asserção da suíte que
+     * depende. Sem Redis o resultado sorteado fica no fallback em memória de
+     * uma instância, e o pedido do pôster cai noutra: 404. Não é falha de
+     * cache nem de rota — é o comportamento que `.env.example` descreve para
+     * serverless, aparecendo onde ele aparece de verdade.
+     */
     expect(poster.status()).toBe(200);
     expect((await poster.body()).subarray(0, 8)).toEqual(PNG_MAGIC);
     // Resultado já sorteado não muda nunca.

--- a/tests/unit/cache-control.test.ts
+++ b/tests/unit/cache-control.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  BATTLE_IMAGE_CACHE_CONTROL,
+  CARD_IMAGE_CACHE_CONTROL,
+} from "@/lib/config";
+
+/**
+ * A política de cache da RFC 4.2 não tinha cobertura nenhuma, e a tentativa de
+ * cobri-la vivia no e2e — no único ângulo em que ela é **invisível**.
+ *
+ * A Vercel consome `s-maxage` e `stale-while-revalidate` para o próprio cache de
+ * borda e não repassa nenhum dos dois ao cliente: a resposta chega com
+ * `public, max-age=3600` e um `x-vercel-cache: HIT` ao lado. O e2e afirmava
+ * `s-maxage=86400` no header recebido e falhava contra uma produção onde a
+ * política estava, de fato, valendo.
+ *
+ * Aqui a política é observável, porque é uma string que nós escrevemos. O e2e
+ * fica com o que só ele pode provar: que a borda cacheou.
+ */
+describe("política de cache das imagens (RFC 4.2)", () => {
+  /** `a=b, c` → `{ a: "b", c: true }`, para asserir diretiva a diretiva. */
+  function parse(header: string): Record<string, string | true> {
+    return Object.fromEntries(
+      header.split(",").map((parte) => {
+        const [nome, valor] = parte.trim().split("=");
+        return [nome.toLowerCase(), valor ?? true];
+      }),
+    );
+  }
+
+  describe("carta", () => {
+    const diretivas = parse(CARD_IMAGE_CACHE_CONTROL);
+
+    it("é pública: a carta vive dentro do README de terceiro, sem sessão", () => {
+      expect(diretivas.public).toBe(true);
+      expect(diretivas.private).toBeUndefined();
+      expect(diretivas["no-store"]).toBeUndefined();
+    });
+
+    it("dá à CDN 24h e ao navegador 1h", () => {
+      expect(diretivas["s-maxage"]).toBe("86400");
+      expect(diretivas["max-age"]).toBe("3600");
+    });
+
+    /*
+     * A janela de revalidação é o que separa "carta velha por uma semana" de
+     * "erro no README de alguém": expirado o s-maxage, a borda serve o que tem
+     * enquanto busca a versão nova, em vez de deixar o visitante esperando a
+     * API do GitHub.
+     */
+    it("serve carta velha enquanto revalida, por uma semana", () => {
+      expect(diretivas["stale-while-revalidate"]).toBe("604800");
+    });
+
+    it("dá ao navegador uma janela menor que a da CDN", () => {
+      // Invertido, a CDN expiraria antes do navegador e a atualização de uma
+      // carta demoraria mais que o previsto — sem nada quebrar visivelmente.
+      expect(Number(diretivas["max-age"])).toBeLessThan(
+        Number(diretivas["s-maxage"]),
+      );
+    });
+  });
+
+  describe("pôster de batalha", () => {
+    const diretivas = parse(BATTLE_IMAGE_CACHE_CONTROL);
+
+    /*
+     * Um resultado já sorteado não muda nunca (RFC 7.3), então aqui o cache é
+     * duro. O que não pode ter cache duro é a rota `/<a>/vs/<b>`, que precisa
+     * sortear de novo a cada visita — e essa não passa por estas constantes.
+     */
+    it("é imutável, porque o resultado já foi sorteado", () => {
+      expect(diretivas.immutable).toBe(true);
+      expect(diretivas["max-age"]).toBe("31536000");
+      expect(diretivas["s-maxage"]).toBe("31536000");
+    });
+
+    it("dura mais que a carta, que ainda pode mudar", () => {
+      expect(Number(diretivas["s-maxage"])).toBeGreaterThan(
+        Number(parse(CARD_IMAGE_CACHE_CONTROL)["s-maxage"]),
+      );
+    });
+  });
+});


### PR DESCRIPTION
O `smoke` de produção falhava desde que existe, por dois motivos somados — e nenhum deles no produto.

## 1. Testava um endereço que ninguém usa

`vercel deploy --prod` imprime a URL **única do deployment**, e era ela que virava `E2E_BASE_URL`. A Standard Protection da Vercel isenta o **domínio** de produção, não a URL de deployment:

```
GET https://gitmon-cards-jl18h1qgi-….vercel.app/torvalds.png
→ 302  location: https://vercel.com/sso-api?…
```

O Playwright seguia o redirect, recebia um `200 text/html` da tela de login, e o relatório acusava as rotas de imagem por devolverem HTML. Enquanto isso, o endereço que as pessoas de fato embutem no README sempre esteve no ar:

```
GET https://gitmon-cards.vercel.app/torvalds.png
→ 200  image/png  x-vercel-cache: HIT
```

Passa a testar o alias público, **sem bypass, de propósito**: se aquele endereço precisar de secret para responder, o produto está quebrado e é isso que tem que falhar.

## 2. Afirmava um header que a plataforma esconde

`expect(cache-control).toContain("s-maxage=86400")` recebia `public, max-age=3600`. Não é a rota servindo política errada — a Vercel **consome** `s-maxage` e `stale-while-revalidate` para o próprio cache de borda e não repassa nenhum dos dois ao cliente. O `x-vercel-cache: HIT` é a prova de que a política da RFC 4.2 está valendo; ela só não é observável no header.

A asserção pedia para ver uma coisa invisível por construção, e o sintoma (`Received: "public, max-age=3600"`) parecia bug de rota.

**A política não tinha cobertura nenhuma** — essa era a única tentativa, e pelo único ângulo em que ela não aparece. Agora são duas coisas separadas:

| onde | o quê |
|---|---|
| `tests/unit/cache-control.test.ts` (novo) | a política, sobre a constante que a declara: diretiva a diretiva, incluindo que `max-age < s-maxage` |
| `smoke.spec.ts` | o que só o e2e prova: que a borda cacheou. Duas requisições, a segunda tem que vir de lá |

Um `MISS` na segunda volta é o que o teste novo passa a pegar — carta regerada por visita esgota o rate limit do token, e nada além da lentidão denunciaria isso.

## Verificação

`--grep '@smoke'` contra `https://gitmon-cards.vercel.app`, sem bypass:

```
6 passed (5.7s)
```

Unitários: **155 → 161**, 13 arquivos.

## O que continua vermelho, e não mexi

O e2e de **preview** ainda falha em "batalha" — o pôster volta **404**. Cheguei a mudar a asserção de `immutable` achando que era o mesmo problema de header; era palpite errado e revertei. A causa real é `REDIS_URL` ausente: o resultado sorteado fica no fallback em memória de uma instância e o pedido do pôster cai noutra. É o comportamento que o `.env.example` descreve para serverless, aparecendo onde ele aparece de verdade. Deixei a asserção como está, com o motivo escrito ao lado.

Também **não é preciso mexer na Deployment Protection** — cheguei a recomendar isso antes e estava errado. O alias de produção já é público.
