### PR TITLE
fix(mobile): corta o sangramento da aureola na tela, e devolve o pacote ao centro

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -76,6 +76,40 @@ html {
   -webkit-text-size-adjust: 100%;
 }
 
+/*
+ * A página não rola de lado. Nunca.
+ *
+ * A auréola do elemento atrás da carta é um quadrado de 620px que sangra para
+ * fora dela de propósito (`.card-center::before`). No telefone ela sangra para
+ * fora da tela junto, e o que fica rolável é a cauda do gradiente — já
+ * transparente, sem nada para ver. O estrago maior é indireto: documento mais
+ * largo que a tela faz o navegador móvel esticar o **viewport de layout** até
+ * caber o vazamento, e é dele que sai a caixa do pacote (`position: fixed;
+ * inset: 0`). A embalagem passa a ser medida em 505px numa tela de 390: sai do
+ * centro e leva o botão de pular para fora da borda.
+ *
+ * São duas linhas e nenhuma sobra:
+ *
+ *   `html`  vira a origem do overflow do viewport. É só o que interessa dela —
+ *           cortar aqui não encolhe o documento, porque a raiz **propaga** o
+ *           valor para o viewport em vez de aplicá-lo em si mesma, e o viewport
+ *           de layout continua esticado (medido: `.pack` seguia com 505px).
+ *   `body`  é quem corta de verdade. Ele só aplica o próprio `overflow` porque a
+ *           linha de cima tirou a raiz do `visible` — sem ela, o `body` seria o
+ *           elemento a propagar, e o corte voltaria a ser o do viewport.
+ *
+ * O corte fica no nível da tela, e não em `.card-center`, porque o sangramento é
+ * intencional: a auréola continua com os 620px inteiros em qualquer largura, e o
+ * que some é só o que já estava fora da tela. `clip` e não `hidden` porque
+ * `hidden` deixa o eixo rolável por script — um `scrollIntoView` de algo que
+ * vazou ainda arrastaria a página de lado, sem barra para desfazer. `overflow-y`
+ * segue `visible` nos dois, então a rolagem vertical não muda.
+ */
+html,
+body {
+  overflow-x: clip;
+}
+
 body {
   margin: 0;
   min-height: 100dvh;

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -189,6 +189,48 @@ test.describe("abertura de pacote", () => {
   });
 });
 
+/*
+ * Rolagem lateral no telefone é falha silenciosa: nada quebra, nada some, a
+ * página só ganha uns 100px de vazio à direita e o polegar escorrega para lá.
+ * A origem era a auréola atrás da carta, um quadrado de 620px que sangra de
+ * propósito — e, por tabela, esticava o viewport de layout, tirando o pacote do
+ * centro da tela. Daí medir o documento, e não a auréola: o sintoma a evitar é
+ * a página larga demais, venha de onde vier.
+ */
+test.describe("largura no telefone", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  for (const path of ["/", "/torvalds", "/torvalds/linux"]) {
+    test(`${path} não rola de lado`, async ({ page }) => {
+      await page.goto(path);
+
+      // Com o pacote na frente e depois sem ele: o overlay é fixo e cobre a
+      // tela, então ele esconderia um vazamento da página atrás.
+      const larguras = async () =>
+        page.evaluate(() => ({
+          tela: document.documentElement.clientWidth,
+          documento: document.documentElement.scrollWidth,
+        }));
+
+      const comPacote = await larguras();
+      expect(comPacote.documento).toBe(comPacote.tela);
+
+      if (await page.locator(".pack").count()) {
+        // O overlay vem no HTML, mas só ouve o teclado depois de hidratar — e
+        // quem avisa que isso aconteceu é o foco que ele próprio move para o
+        // botão de rasgar. Sem esperar por ele, o Escape se perde e o pacote
+        // fica na tela.
+        await expect(page.locator(".pack-wrapper")).toBeFocused();
+        await page.keyboard.press("Escape");
+        await expect(page.locator(".pack")).toHaveCount(0);
+      }
+
+      const semPacote = await larguras();
+      expect(semPacote.documento).toBe(semPacote.tela);
+    });
+  }
+});
+
 test.describe("virar a carta", () => {
   test("clique no perfil revela o verso e outro clique volta", async ({ page }) => {
     await page.goto("/torvalds");

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -164,6 +164,16 @@ test.describe("abertura de pacote", () => {
 
   test("Escape pula a abertura", async ({ page }) => {
     await page.goto("/torvalds");
+
+    /*
+     * Esperar o foco antes de digitar não é zelo: o overlay vem pronto no HTML,
+     * mas quem ouve o Escape é um listener que só existe depois da hidratação.
+     * Um Escape mandado antes dela não é adiado, é perdido — e o teste falha
+     * acusando o pacote, que estava certo. O foco no botão de rasgar é o sinal
+     * de que o componente montou, e é o mesmo que o teste de confinamento já
+     * espera antes de mandar Tab.
+     */
+    await expect(page.locator(".pack-wrapper")).toBeFocused();
     await page.keyboard.press("Escape");
 
     await expect(page.locator(".pack")).toHaveCount(0);


### PR DESCRIPTION
## What changed, and why

Fecha #16: a página da carta rolava de lado no telefone.

**A origem não é o pacote.** É a auréola do elemento atrás da carta — `.card-center::before`, um quadrado de 620px que sangra da carta de propósito. Num viewport de 390 ela sangra para fora da tela também: `scrollWidth` 505 contra `clientWidth` 390. Como é pseudo-elemento, não aparece em varredura de DOM; só no `scrollWidth` do `.card-center` (485 contra 350 de `clientWidth`).

**O pacote entra como vítima, e é por isso que parecia o culpado.** Documento mais largo que a tela faz o navegador móvel esticar o *viewport de layout* até caber o vazamento, e é dele que sai a caixa de `position: fixed; inset: 0`. Medido: `.pack` ficava com 505px numa tela de 390 — saía do centro e levava o botão "Pular abertura" para fora da borda (a 320px o Playwright nem conseguia clicar nele, o overlay interceptava o ponteiro).

### Por que duas linhas, e não uma

`overflow-x: clip` na raiz **e** no `body`. Medi cada variante em 390×844, em `/torvalds`:

| variante | `scrollWidth` | largura do `.pack` |
| --- | --- | --- |
| sem correção | 505 | 505 |
| só `html` | 505 | **505** |
| só `body` | 505 | **505** |
| `html` + `body` | 390 | 390 |

Só na raiz não resolve: ela **propaga** o valor para o viewport em vez de aplicá-lo em si mesma, o documento continua largo e o viewport de layout esticado. Só no `body` também não: com a raiz em `visible`, quem propaga é o `body`, e cai no mesmo caso. A linha da raiz existe para tirar o `body` do papel de propagador — e aí o corte acontece no `body`, na largura da tela.

### Alternativas descartadas

- **Cortar em `.card-center`**: a auréola vira um retângulo duro. O sangramento é intencional.
- **Encolher a auréola (`width: min(620px, 100%)`)**: o gradiente é `circle` sem tamanho, então escala com a caixa — a 350px o brilho fica menor que a carta. Perde no telefone, que é justamente onde o bug aparece.
- **Cortar em `.shell`**: quebra o desktop, onde `.card-panel` escapa do shell de propósito (`width: min(1360px, 100vw - 40px)`).
- **`hidden` em vez de `clip`**: `hidden` deixa o eixo rolável por script — um `scrollIntoView` de algo que vazou ainda arrastaria a página de lado, agora sem barra para desfazer.

O corte fica no nível da tela, então a auréola mantém os 620px inteiros e some só o que já estava fora do viewport — que ali é cauda de gradiente já transparente.

### O segundo commit

`test(e2e): espera a hidratacao antes de mandar Escape no pacote` — corrige uma flakiness pré-existente que apareceu enquanto eu rodava a suíte. O overlay vem pronto no HTML, mas quem ouve o Escape é um listener que só existe depois da hidratação; Escape mandado antes dela não fica na fila, some, e o teste falhava acusando o pacote. Reproduzido de forma determinística com a CPU estrangulada em 20× via CDP (Escape imediato deixa o pacote na tela; Escape depois do foco dispensa). A espera é o mesmo sinal que o teste de confinamento de foco já usava antes de mandar Tab.

## What you saw

Rodei `npm run dev` e olhei, em 390×844 e em 1440×900:

- **Telefone, pacote lacrado**: a embalagem volta ao centro da tela e o "Pular abertura" cabe inteiro na largura. Antes ficava descentrado, com o botão pela metade fora da borda.
- **Telefone, carta revelada**: a auréola continua igual — como o corte é na borda da tela e o que passava dela já era gradiente transparente, não há diferença visível.
- **Desktop**: sem mudança. As três colunas seguem lá e o painel mantém o full bleed (mede 40..1400 numa viewport de 1440).
- **Durante o rasgo do pacote**: a tira sai para a direita e o documento fica em 390 — antes essa animação também vazava.

Medições em `/`, `/torvalds`, `/torvalds/linux` e `/battle/…`, a 320px e 390px: todas com `scrollWidth == clientWidth` depois da correção. Home e batalha já estavam limpas.

O teste e2e novo (`largura no telefone`) mede o documento, e não a auréola: o sintoma a evitar é a página mais larga que a tela, venha de onde vier. Confirmei que ele **falha sem a correção** (505 ≠ 390) revertendo o CSS.

## Checks

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (161 testes, 13 arquivos)
- [ ] Touched the card's shape (new field, removed enum value)? Bumped `CARD_VERSION` in `lib/cards/index.ts` — não toquei
- [ ] Touched a scoring formula? — não toquei
- [ ] Added an i18n key? — nenhuma

E2E local contra `npm run dev`: os testes de layout e de pacote passam. Ficaram falhando as rotas de imagem e o pôster de batalha, por `page.goto` estourando 30s com o servidor de dev frio nesta máquina ("Slow filesystem detected") e pelo pôster depender de `REDIS_URL` — nenhuma delas toca CSS. A esteira contra o preview é quem dá a palavra final aí.
