### PR TITLE
feat(pack): o rasgo revela o verso da carta, e a pagina atras fica borrada

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -635,6 +635,11 @@ select {
 /*
  * O visitante rasga a tira serrilhada e a carta aparece atrás. Toda a
  * coreografia é `clip-path` + `transform`; o React só troca `data-stage`.
+ *
+ * O fundo vem quase opaco e ainda borra atrás de si: a página que já tem a
+ * carta visível (revisitar, voltar) não deve deixar o status vazar antes da
+ * revelação. A camada escura já esconde quase tudo — o que sobra, borrado,
+ * deixa de se ler como carta.
  */
 
 .pack {
@@ -647,6 +652,8 @@ select {
   justify-content: center;
   gap: 28px;
   background: rgb(9 11 15 / 0.92);
+  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(14px);
   animation: pack-in 220ms ease both;
 }
 

--- a/components/card/CardPanel.tsx
+++ b/components/card/CardPanel.tsx
@@ -22,7 +22,11 @@ export function CardPanel({
 }: {
   card: Card;
   locale: Locale;
-  /** Liga o flip da carta. Só o perfil vira; o repositório e a home não. */
+  /**
+   * Liga o flip da carta. Só o perfil vira; o repositório e a home não. Quem
+   * vira também nasce virado (verso para cima): o pacote revela o verso, e o
+   * gesto de virar é quem entrega a frente.
+   */
   flippable?: boolean;
   children?: React.ReactNode;
 }) {
@@ -70,6 +74,7 @@ export function CardPanel({
           priority
           rarity={card.rarity}
           flippable={flippable}
+          startFlipped={flippable}
           locale={locale}
         />
         <div className="card-headline">

--- a/components/card/TiltCard.tsx
+++ b/components/card/TiltCard.tsx
@@ -58,6 +58,7 @@ export function TiltCard({
   priority = false,
   rarity,
   flippable = false,
+  startFlipped = false,
   back = "/assets/backs/card-back.svg",
   locale,
 }: {
@@ -76,6 +77,13 @@ export function TiltCard({
    */
   flippable?: boolean;
   /**
+   * A carta nasce virada, com o verso para cima. É o suspense do perfil: o
+   * pacote abre e o que se revela é o verso, não os status — quem entrega a
+   * frente é o gesto de virar. Vale só no primeiro render; dali em diante o
+   * estado é do clique, e sem `flippable` isto não muda nada (não há verso).
+   */
+  startFlipped?: boolean;
+  /**
    * Arte do verso. O mesmo PNG para qualquer carta — é o verso da marca.
    *
    * Qualquer caminho sob `/assets/` serve: a rewrite `/:owner/:repo.png` do
@@ -89,7 +97,7 @@ export function TiltCard({
   const cardRef = useRef<HTMLDivElement>(null);
   const lightRef = useRef<SVGFEPointLightElement>(null);
 
-  const [flipped, setFlipped] = useState(false);
+  const [flipped, setFlipped] = useState(startFlipped);
   const t = translator(locale ?? DEFAULT_LOCALE);
 
   const target = useRef<Pointer>({ px: 0.5, py: 0.5, active: 0 });

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -144,22 +144,28 @@ test.describe("abertura de pacote", () => {
     await expect(page.locator(".pack-wrapper")).toBeFocused();
   });
 
-  test("pular dispensa o pacote e revela a carta", async ({ page }) => {
+  test("pular dispensa o pacote e revela o verso", async ({ page }) => {
     await page.goto("/torvalds");
     await page.locator(".pack-skip").click();
 
     await expect(page.locator(".pack")).toHaveCount(0);
-    await expect(page.locator(".tilt-face-front img")).toBeVisible();
+    // O rasgo revela o verso, não a frente: os status são a recompensa do gesto
+    // de virar, e não vão aparecer de graça no bolso do botão de pular.
+    await expect(page.locator(".tilt-inner")).toHaveAttribute("data-flipped", "true");
+    await expect(page.locator(".tilt-face-back img")).toHaveAttribute(
+      "src",
+      "/assets/backs/card-back.svg",
+    );
   });
 
-  test("rasgar dispensa o pacote e revela a carta", async ({ page }) => {
+  test("rasgar dispensa o pacote e revela o verso", async ({ page }) => {
     await page.goto("/torvalds");
     await page.locator(".pack-wrapper").click();
 
     // A coreografia inteira tem menos de 1s; o overlay se desmonta sozinho ao
     // fim dela, sem ninguém precisar clicar de novo.
     await expect(page.locator(".pack")).toHaveCount(0, { timeout: 5000 });
-    await expect(page.locator(".tilt-face-front img")).toBeVisible();
+    await expect(page.locator(".tilt-inner")).toHaveAttribute("data-flipped", "true");
   });
 
   test("Escape pula a abertura", async ({ page }) => {
@@ -241,8 +247,13 @@ test.describe("largura no telefone", () => {
   }
 });
 
+/*
+ * O flip do perfil nasce virado: quem abre o pacote recebe o verso, e a frente
+ * (com os status) é a recompensa de um clique ou de um Enter. Nada disso existe
+ * na home — lá a carta de exemplo é só um link.
+ */
 test.describe("virar a carta", () => {
-  test("clique no perfil revela o verso e outro clique volta", async ({ page }) => {
+  test("o perfil chega virado e um clique entrega a frente", async ({ page }) => {
     await page.goto("/torvalds");
     await page.locator(".pack-skip").click();
 
@@ -250,7 +261,7 @@ test.describe("virar a carta", () => {
     // Virável é `role="button"`, não link: o clique vira, não navega.
     await expect(card).toHaveAttribute("role", "button");
 
-    await card.click();
+    // Nasceu virado: o verso para cima, a frente escondida.
     await expect(page.locator(".tilt-inner")).toHaveAttribute("data-flipped", "true");
     await expect(page.locator(".tilt-face-back img")).toHaveAttribute(
       "src",
@@ -259,11 +270,18 @@ test.describe("virar a carta", () => {
 
     await card.click();
     await expect(page.locator(".tilt-inner")).not.toHaveAttribute("data-flipped", "true");
+
+    await card.click();
+    await expect(page.locator(".tilt-inner")).toHaveAttribute("data-flipped", "true");
   });
 
-  test("teclado vira a carta com Enter", async ({ page }) => {
+  test("teclado devolve o verso com Enter", async ({ page }) => {
     await page.goto("/torvalds");
     await page.locator(".pack-skip").click();
+
+    // Do verso para a frente com um clique, e o Enter traz o verso de volta.
+    await page.locator(".tilt-card").click();
+    await expect(page.locator(".tilt-inner")).not.toHaveAttribute("data-flipped", "true");
 
     await page.locator(".tilt-card").focus();
     await page.keyboard.press("Enter");


### PR DESCRIPTION
## O que muda

O ritual de revelação da carta de perfil ganha suspense, e o fundo para de vazar o resultado antes da hora:

**1. O rasgo revela o verso, não a frente**
- `TiltCard` ganha `startFlipped`: a carta pode nascer virada, com o verso para cima.
- No perfil (`CardPanel`), quem é virável nasce virado — o pacote entrega o verso, e os status são a recompensa de um clique (ou Enter). A home e o repositório não mudam (sem verso, lá).
- O PNG exportado continua só com a frente (RFC 9.6); o flip segue sendo experiência do site.

**2. A página atrás do pacote fica borrada**
- `.pack` ganha `backdrop-filter: blur(14px)` (com `-webkit-` para o Safari). Na revisita/volta, a carta e os status já visíveis atrás da camada escura deixam de se ler como carta antes da revelação.

## Arquivos
- `app/globals.css` — blur atrás do overlay do pacote
- `components/card/TiltCard.tsx` — prop `startFlipped`
- `components/card/CardPanel.tsx` — o perfil nasce virado
- `tests/e2e/smoke.spec.ts` — testes atualizados para o novo desfecho

## Verificação
- `tsc --noEmit` limpo
- 161 testes unitários passam
- 11 e2e passam (abertura de pacote, virar a carta, largura no telefone)
- Probe: `backdrop-filter: blur(14px)` aplicado; `data-flipped=true` após pular → `null` após o clique
