### PR TITLE
feat(home): a landing cabe numa tela, com trama no fundo e as cartas na mao

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1105,8 +1105,21 @@ select {
   white-space: nowrap;
 }
 
-.search-form button,
-.battle-form button {
+/*
+ * `button[type="submit"]`, e não `button`.
+ *
+ * O autocomplete mora **dentro** do formulário, e cada sugestão dele é um
+ * `<button>`. Com o seletor solto, esta regra alcançava as seis: `.search-form
+ * button` (0,1,1) ganha de `.search-dropdown-item` (0,1,0) na cascata, e a lista
+ * inteira saía pintada de amarelo, com o padding do botão de envio. O `:hover`
+ * do item (0,2,0) voltava a vencer, então a linha sob o cursor era a única
+ * escura — o que fazia o sintoma parecer intencional.
+ *
+ * O tipo é o critério certo porque é o que de fato separa os dois: um envia o
+ * formulário, os outros escolhem um nome.
+ */
+.search-form button[type="submit"],
+.battle-form button[type="submit"] {
   padding: 11px 20px;
   border-radius: var(--radius);
   border: 0;
@@ -1133,9 +1146,285 @@ select {
   font-weight: 600;
 }
 
+/* ------------------------------------------------ a home em uma tela só */
+
+/*
+ * A home não rola. É a única página do site em que isso faz sentido: ela tem
+ * três coisas para dizer (o que é, como usar, como é o resultado) e as três
+ * cabem juntas — enquanto a página de uma carta tem stats, derivações, embed e
+ * batalha, que não cabem nem deveriam.
+ *
+ * Tudo aqui está preso ao mesmo eixo vertical: título, descrição, busca e as
+ * três cartas dividem o mesmo centro, e cabeçalho e faixa de apoio fecham a
+ * composição em cima e embaixo com o mesmo fio de 1px. O alinhamento é o que
+ * substitui a decoração que a página não tem.
+ */
+
+/*
+ * A trama do `DitherBackground` (React Bits). Fixa, atrás de tudo e sem eventos:
+ * ela não é interface, é atmosfera.
+ *
+ * `z-index: -1` funciona porque nada no caminho até a raiz cria contexto de
+ * empilhamento — o canvas cai atrás do conteúdo do documento e ainda assim
+ * **na frente** do fundo da página, que é onde a onda precisa estar para
+ * compor com `--bg` em vez de substituí-lo.
+ */
+.dither {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  opacity: 0.5;
+
+  /*
+   * O buffer tem o tamanho em pixels de CSS e o navegador o estica para os
+   * pixels do aparelho. Sem isto ele interpola, e a interpolação borra
+   * justamente a única coisa que a trama tem: a borda dura da célula.
+   */
+  image-rendering: pixelated;
+
+  /*
+   * Buraco no meio. A trama existe para o quadro respirar, não para o título
+   * competir com ela — a máscara a apaga onde o texto e as cartas moram e a
+   * devolve inteira nas bordas, que é onde uma moldura deve estar.
+   */
+  -webkit-mask-image: radial-gradient(
+    ellipse 72% 58% at 50% 46%,
+    transparent 6%,
+    rgb(0 0 0 / 0.45) 44%,
+    #000 84%
+  );
+  mask-image: radial-gradient(
+    ellipse 72% 58% at 50% 46%,
+    transparent 6%,
+    rgb(0 0 0 / 0.45) 44%,
+    #000 84%
+  );
+}
+
+/*
+ * O corte de altura, e não de largura.
+ *
+ * Abaixo disto (celular deitado, janela achatada) travar a home em 100dvh não
+ * deixa nada caber — só espreme. Lá ela volta a rolar, que é o comportamento
+ * honesto: "sem scroll" é uma promessa sobre a composição, não sobre a régua.
+ */
+@media (min-height: 560px) {
+  /*
+   * A altura já está resolvida; a barra de rolagem seria só um resíduo de
+   * arredondamento aparecendo e sumindo.
+   *
+   * `overflow-y`, e não o atalho `overflow`: o eixo horizontal já é cortado lá
+   * em cima, na regra que existe para o pacote não sair do centro no telefone, e
+   * o atalho aqui apagaria aquilo justamente na home. Pelo mesmo motivo o corte
+   * é `clip` e vai nos dois elementos — a raiz propaga o próprio valor para o
+   * viewport em vez de aplicá-lo em si, então quem corta de verdade é o `body`,
+   * e só depois de a linha da raiz tirá-lo do papel de propagador.
+   */
+  html:has(.shell[data-landing]),
+  body:has(.shell[data-landing]) {
+    overflow-y: clip;
+  }
+
+  .shell[data-landing] {
+    height: 100dvh;
+  }
+
+  .shell[data-landing] .shell-header {
+    padding: 16px 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  /* O miolo toma o que sobra e centra dentro dele — é daqui que vem o eixo. */
+  .shell[data-landing] .shell-main {
+    flex: 1;
+    min-height: 0;
+    align-items: center;
+    justify-content: center;
+    gap: clamp(20px, 4.5vh, 52px);
+    padding: 0;
+  }
+
+  .shell[data-landing] .hero {
+    align-items: center;
+    text-align: center;
+    gap: clamp(8px, 1.6vh, 16px);
+    padding-top: 0;
+    max-width: 38rem;
+  }
+
+  /*
+   * Cresce com a altura, mas com teto na largura.
+   *
+   * O que aperta esta página é a altura — daí o `vh` mandar. Sozinho ele erra
+   * nos dois extremos: no celular em pé (844 de altura, 390 de largura) o título
+   * fica maior do que a coluna comporta e quebra em quatro linhas, e numa janela
+   * baixa e larga ele encolhe sem precisar. O `min` com `vw` é o teto que faltava.
+   */
+  .shell[data-landing] .hero h1 {
+    font-size: clamp(26px, min(4.4vh, 8vw), 44px);
+    text-wrap: balance;
+  }
+
+  .shell[data-landing] .hero p {
+    font-size: clamp(14px, 1.9vh, 17px);
+    max-width: 44ch;
+    text-wrap: balance;
+  }
+
+  /* Sem quebra: a busca é uma peça só, e o botão descendo para uma segunda
+     linha desfaz o eixo central na única linha que tem duas coisas. */
+  .shell[data-landing] .search-form {
+    width: 100%;
+    max-width: 27rem;
+    margin-top: clamp(4px, 1.2vh, 12px);
+    flex-wrap: nowrap;
+    justify-content: center;
+  }
+
+  /* Quem cede largura é o campo, que tem `min-width: 0` para isso. O rótulo do
+     botão quebrado ao meio ("Gerar / carta") é o que acontece sem esta linha. */
+  .shell[data-landing] .search-form button {
+    white-space: nowrap;
+  }
+
+  /*
+   * As três encostadas, como cartas na mão.
+   *
+   * Largura tomada pelo menor de três limites: o teto de 224px, o que cabe na
+   * largura da janela e o que cabe na altura dela. A carta é 5:7, então largura
+   * é o único número a controlar — a altura vem junto.
+   *
+   * `flex` e não `grid`: o encaixe é feito com margem negativa, e três colunas
+   * de grade com margem negativa continuam reservando a largura da coluna
+   * inteira — a fileira ficaria descentrada por duas sobreposições.
+   */
+  .shell[data-landing] .samples {
+    --sample-w: min(224px, (100vw - 40px) / 3, 22vh);
+    /*
+     * Quanto cada carta avança sobre a vizinha, de cada lado. Baixo de
+     * propósito: os PS ficam no canto superior direito da arte, e passando de
+     * ~4% a vizinha começa a comer o número.
+     */
+    --sample-lap: calc(var(--sample-w) * 0.04);
+
+    display: flex;
+    justify-content: center;
+    gap: 0;
+  }
+
+  /* O rótulo é um identificador do GitHub, e passa a ser desenhado como um:
+     mesma mono da busca logo acima, que é onde ele seria digitado. */
+  .shell[data-landing] .sample {
+    position: relative;
+    width: var(--sample-w);
+    margin-inline: calc(var(--sample-lap) * -1);
+    gap: clamp(6px, 1.2vh, 12px);
+    font-family: var(--font-mono);
+    font-size: clamp(11px, 1.5vh, 13.5px);
+    font-weight: 500;
+    letter-spacing: -0.2px;
+    transition: transform 340ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  /*
+   * A carta apontada sai da pilha: sobe, vem para a frente e empurra as outras
+   * duas para fora. É o gesto de tirar uma carta da mão — e resolve o custo da
+   * sobreposição, que é justamente esconder a borda da vizinha.
+   *
+   * O afastamento é maior que a sobreposição (×3), então o vão abre de verdade
+   * em vez de só desencostar.
+   */
+  .shell[data-landing] .sample:hover,
+  .shell[data-landing] .sample:focus-visible {
+    z-index: 2;
+  }
+
+  /*
+   * Quem sobe é a carta, não o item inteiro: os três rótulos estão numa linha
+   * de base só, e levantar um deles junto quebraria justamente o alinhamento
+   * que esta página existe para ter. O deslocamento lateral fica no item —
+   * ali o rótulo *deve* acompanhar, porque ele pertence à carta que se afastou.
+   */
+  .shell[data-landing] .sample .tilt-scene {
+    transition: transform 340ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .shell[data-landing] .sample:hover .tilt-scene,
+  .shell[data-landing] .sample:focus-visible .tilt-scene {
+    transform: translateY(-6%);
+  }
+
+  .shell[data-landing] .sample:hover ~ .sample,
+  .shell[data-landing] .sample:focus-visible ~ .sample {
+    transform: translateX(calc(var(--sample-lap) * 3));
+  }
+
+  /*
+   * As de trás. Irmão anterior não tem combinador — `:has(~ …)` é o que
+   * pergunta "existe uma carta apontada depois de mim?" e é a única forma de o
+   * afastamento valer para os dois lados sem duplicar a marcação.
+   */
+  .shell[data-landing] .sample:has(~ .sample:hover),
+  .shell[data-landing] .sample:has(~ .sample:focus-visible) {
+    transform: translateX(calc(var(--sample-lap) * -3));
+  }
+
+  .shell[data-landing] .shell-footer {
+    padding: 12px 0;
+  }
+}
+
+/*
+ * Faixa de apoio em uma linha. Fora da media query de propósito: quando a home
+ * rola, ela continua sendo a versão curta — a descrição saiu porque nesta
+ * página ela era redundante, não porque faltava espaço.
+ */
+.support-band[data-compact] {
+  margin: 0 0 14px;
+  padding: 12px 18px;
+  gap: 14px;
+  /*
+   * Translúcida, porque a trama passa por trás. Uma superfície opaca aqui
+   * recortaria um retângulo cego no fundo, bem na borda de baixo, que é onde a
+   * onda está mais forte.
+   */
+  background: color-mix(in srgb, var(--bg-raised) 74%, transparent);
+  backdrop-filter: blur(10px);
+}
+
+.support-band[data-compact] .support-copy h2 {
+  font-size: 15px;
+}
+
+.support-band[data-compact] .support-star,
+.support-band[data-compact] .button {
+  padding: 7px 14px;
+  font-size: 13px;
+}
+
 /* ------------------------------------------------------------ carta 3D */
 
+/*
+ * O canto da carta é proporcional a ela, e não a um número fixo.
+ *
+ * Os 16px foram desenhados para a carta grande da página de perfil, onde ela tem
+ * 340px de largura. Na home, a mesma carta aparece a 200 ou a 110 — e 16px ali é
+ * quase 15% da largura: o canto começa a comer a moldura impressa no PNG, que
+ * tem o próprio raio, e as duas curvas deixam de coincidir.
+ *
+ * `cqw` porque a medida certa é a largura da própria carta, e nenhuma unidade
+ * fora de container query sabe disso: `%` em `border-radius` mede largura na
+ * horizontal e **altura** na vertical, o que numa carta 5:7 devolve um canto
+ * elíptico. Os 4.7% reproduzem exatamente os 16px nos 340 de origem, então a
+ * página de perfil não muda de aparência.
+ */
 .tilt-scene {
+  container-type: inline-size;
+  --tilt-radius: 4.7cqw;
+
   perspective: 1100px;
   width: 100%;
   max-width: 340px;
@@ -1143,7 +1432,7 @@ select {
 
 .tilt-card {
   position: relative;
-  border-radius: 16px;
+  border-radius: var(--tilt-radius);
 
   /*
    * `--active` vai de 0 a 1 no laço de rAF do TiltCard e é o dimmer de toda a
@@ -1174,7 +1463,7 @@ select {
 .tilt-card img {
   width: 100%;
   height: auto;
-  border-radius: 16px;
+  border-radius: var(--tilt-radius);
   /*
    * A sombra cresce com a elevação: carta levantada projeta sombra maior e mais
    * difusa. Sem isso o `translateZ` lê como zoom, não como altura.
@@ -1188,7 +1477,7 @@ select {
 .tilt-glare {
   position: absolute;
   inset: 0;
-  border-radius: 16px;
+  border-radius: var(--tilt-radius);
   pointer-events: none;
   opacity: var(--active);
   /*
@@ -1240,7 +1529,7 @@ select {
   position: absolute;
   inset: 0;
   transform: rotateY(180deg);
-  border-radius: 16px;
+  border-radius: var(--tilt-radius);
 }
 
 /*
@@ -1267,7 +1556,7 @@ select {
 .tilt-holo {
   position: absolute;
   inset: 0;
-  border-radius: 16px;
+  border-radius: var(--tilt-radius);
   overflow: hidden;
   pointer-events: none;
 }
@@ -1402,7 +1691,7 @@ select {
   content: "";
   position: absolute;
   inset: 0;
-  border-radius: 16px;
+  border-radius: var(--tilt-radius);
   pointer-events: none;
   padding: 1px;
   opacity: calc(var(--foil) * (0.25 + var(--active) * 0.6));

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,7 +20,7 @@ export default async function HomePage() {
   const t = translator(locale);
 
   return (
-    <Shell locale={locale}>
+    <Shell locale={locale} landing>
       <section className="hero">
         <h1>{t("home.tagline")}</h1>
         <p>{t("home.description")}</p>

--- a/components/ui/DitherBackground.tsx
+++ b/components/ui/DitherBackground.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Fundo de ondas com trama ordenada (dithering), atrás da home.
+ *
+ * Porta do `Dither` do React Bits — mesma receita: ruído simplex somado em
+ * oitavas (fbm) desenha ondas lentas, a imagem é quantizada em poucos níveis e
+ * uma matriz de Bayer 8×8 espalha o erro dessa quantização em pontinhos. É o
+ * ponto: sem a trama, quatro níveis viram faixas chapadas; com ela, viram grão.
+ *
+ * O original roda sobre `three` + `@react-three/fiber` + `postprocessing`, em
+ * dois passes com render target no meio. Aqui é um `<canvas>` de WebGL cru e um
+ * pass só — o mesmo que `TiltCard` fez com o `ReflectiveCard` da mesma
+ * biblioteca (ver `docs/foil-especular.md`). O motivo é o mesmo dos dois casos:
+ * o projeto inteiro tem cinco dependências de runtime, e ~600 KB de motor 3D
+ * para desenhar um quad de tela cheia não passa nesse orçamento. O segundo pass
+ * do original também não é necessário: pixelar antes de amostrar dá o mesmo
+ * resultado que renderizar grande e reduzir depois.
+ *
+ * A saída sai em **alpha**, não em RGB: o canvas é transparente e quem pinta o
+ * preto continua sendo `--bg` do site. Assim o fundo do produto é um só, e a
+ * trama é uma camada por cima dele — se este componente não montar (WebGL
+ * indisponível, JS desligado), a home fica exatamente como era.
+ */
+
+/** Níveis de quantização. Em 4 a trama ainda lê como trama; em 8 vira degradê. */
+const STEPS = 4;
+
+/** Lado da célula, em pixels de CSS. O canvas é upscalado com `pixelated`. */
+const PIXEL = 2;
+
+/** Cor da onda — ardósia fria, deliberadamente longe do amarelo da marca. */
+const WAVE = [0.42, 0.48, 0.63];
+
+/** Avanço no eixo de tempo do ruído, por segundo. */
+const SPEED = 0.055;
+
+const VERTEX = `attribute vec2 aPos;
+void main() { gl_Position = vec4(aPos, 0.0, 1.0); }`;
+
+const FRAGMENT = `precision mediump float;
+
+uniform vec2 uResolution;
+uniform float uTime;
+uniform vec2 uPointer;
+uniform float uPointerOn;
+uniform vec3 uWave;
+uniform float uPixel;
+uniform float uSteps;
+
+/* Simplex 3D de Ashima/Gustavson, domínio público. A terceira dimensão é o
+   tempo: é o que faz a onda deslizar em vez de piscar. */
+vec3 mod289(vec3 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
+vec4 mod289(vec4 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
+vec4 permute(vec4 x) { return mod289(((x * 34.0) + 1.0) * x); }
+vec4 taylorInvSqrt(vec4 r) { return 1.79284291400159 - 0.85373472095314 * r; }
+
+float snoise(vec3 v) {
+  const vec2 C = vec2(1.0 / 6.0, 1.0 / 3.0);
+  const vec4 D = vec4(0.0, 0.5, 1.0, 2.0);
+
+  vec3 i = floor(v + dot(v, C.yyy));
+  vec3 x0 = v - i + dot(i, C.xxx);
+
+  vec3 g = step(x0.yzx, x0.xyz);
+  vec3 l = 1.0 - g;
+  vec3 i1 = min(g.xyz, l.zxy);
+  vec3 i2 = max(g.xyz, l.zxy);
+
+  vec3 x1 = x0 - i1 + C.xxx;
+  vec3 x2 = x0 - i2 + C.yyy;
+  vec3 x3 = x0 - D.yyy;
+
+  i = mod289(i);
+  vec4 p = permute(permute(permute(
+      i.z + vec4(0.0, i1.z, i2.z, 1.0))
+    + i.y + vec4(0.0, i1.y, i2.y, 1.0))
+    + i.x + vec4(0.0, i1.x, i2.x, 1.0));
+
+  float n_ = 0.142857142857;
+  vec3 ns = n_ * D.wyz - D.xzx;
+
+  vec4 j = p - 49.0 * floor(p * ns.z * ns.z);
+
+  vec4 x_ = floor(j * ns.z);
+  vec4 y_ = floor(j - 7.0 * x_);
+
+  vec4 x = x_ * ns.x + ns.yyyy;
+  vec4 y = y_ * ns.x + ns.yyyy;
+  vec4 h = 1.0 - abs(x) - abs(y);
+
+  vec4 b0 = vec4(x.xy, y.xy);
+  vec4 b1 = vec4(x.zw, y.zw);
+
+  vec4 s0 = floor(b0) * 2.0 + 1.0;
+  vec4 s1 = floor(b1) * 2.0 + 1.0;
+  vec4 sh = -step(h, vec4(0.0));
+
+  vec4 a0 = b0.xzyw + s0.xzyw * sh.xxyy;
+  vec4 a1 = b1.xzyw + s1.xzyw * sh.zzww;
+
+  vec3 p0 = vec3(a0.xy, h.x);
+  vec3 p1 = vec3(a0.zw, h.y);
+  vec3 p2 = vec3(a1.xy, h.z);
+  vec3 p3 = vec3(a1.zw, h.w);
+
+  vec4 norm = taylorInvSqrt(vec4(dot(p0, p0), dot(p1, p1), dot(p2, p2), dot(p3, p3)));
+  p0 *= norm.x;
+  p1 *= norm.y;
+  p2 *= norm.z;
+  p3 *= norm.w;
+
+  vec4 m = max(0.6 - vec4(dot(x0, x0), dot(x1, x1), dot(x2, x2), dot(x3, x3)), 0.0);
+  m = m * m;
+  return 42.0 * dot(m * m, vec4(dot(p0, x0), dot(p1, x1), dot(p2, x2), dot(p3, x3)));
+}
+
+/*
+ * Bayer 8×8 por recursão, e não como tabela de 64 constantes: array com lista de
+ * inicialização não existe em GLSL ES 1.0, e usar a versão com tabela obrigaria
+ * o shader inteiro a subir para WebGL 2 — mais superfície de falha do que este
+ * enfeite justifica. A matriz 2×2 sai de fract(x/2 + y²·3/4), que dá
+ * [0, 2; 3, 1]/4, e cada nível seguinte é o anterior meio passo menor somado a
+ * ela: é a própria definição da matriz ordenada.
+ */
+float bayer2(vec2 a) {
+  a = floor(a);
+  return fract(a.x * 0.5 + a.y * a.y * 0.75);
+}
+#define bayer4(a) (bayer2(0.5 * (a)) * 0.25 + bayer2(a))
+#define bayer8(a) (bayer4(0.5 * (a)) * 0.25 + bayer2(a))
+
+float fbm(vec3 p) {
+  float value = 0.0;
+  float amp = 0.5;
+  for (int i = 0; i < 4; i++) {
+    value += amp * abs(snoise(p));
+    p *= 2.4;
+    amp *= 0.45;
+  }
+  return value;
+}
+
+void main() {
+  /*
+   * A célula é a unidade de tudo: a onda é amostrada no centro dela (é isto que
+   * pixela) e o limiar de Bayer é indexado por ela (é isto que faz a trama
+   * ficar parada em relação à tela, em vez de nadar junto com a onda).
+   */
+  vec2 cell = floor(gl_FragCoord.xy / uPixel);
+  vec2 uv = ((cell + 0.5) * uPixel) / uResolution - 0.5;
+  uv.x *= uResolution.x / uResolution.y;
+
+  float wave = fbm(vec3(uv * 2.1, uTime));
+
+  vec2 pointer = uPointer / uResolution - 0.5;
+  pointer.x *= uResolution.x / uResolution.y;
+  wave += uPointerOn * 0.45 * (1.0 - smoothstep(0.0, 0.3, length(uv - pointer)));
+
+  float levels = uSteps - 1.0;
+  wave += (bayer8(cell) - 0.5) / levels;
+  wave = floor(wave * levels + 0.5) / levels;
+
+  gl_FragColor = vec4(uWave, clamp(wave, 0.0, 1.0));
+}`;
+
+function compile(gl: WebGLRenderingContext, type: number, source: string) {
+  const shader = gl.createShader(type);
+  if (!shader) return null;
+
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    gl.deleteShader(shader);
+    return null;
+  }
+
+  return shader;
+}
+
+function link(gl: WebGLRenderingContext) {
+  const vertex = compile(gl, gl.VERTEX_SHADER, VERTEX);
+  const fragment = compile(gl, gl.FRAGMENT_SHADER, FRAGMENT);
+  if (!vertex || !fragment) return null;
+
+  const program = gl.createProgram();
+  if (!program) return null;
+
+  gl.attachShader(program, vertex);
+  gl.attachShader(program, fragment);
+  gl.linkProgram(program);
+  gl.deleteShader(vertex);
+  gl.deleteShader(fragment);
+
+  return gl.getProgramParameter(program, gl.LINK_STATUS) ? program : null;
+}
+
+export function DitherBackground() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const gl = canvas.getContext("webgl", {
+      alpha: true,
+      // Sem isto o navegador espera cor já multiplicada pelo alpha, e a onda
+      // sai escurecida exatamente onde ela é mais fraca.
+      premultipliedAlpha: false,
+      antialias: false,
+      depth: false,
+      stencil: false,
+      powerPreference: "low-power",
+    });
+    if (!gl) return;
+
+    const program = link(gl);
+    if (!program) return;
+
+    gl.useProgram(program);
+
+    // Um triângulo que cobre a tela, e não dois formando um quad: metade dos
+    // vértices e nenhuma costura na diagonal.
+    const buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      new Float32Array([-1, -1, 3, -1, -1, 3]),
+      gl.STATIC_DRAW,
+    );
+
+    const position = gl.getAttribLocation(program, "aPos");
+    gl.enableVertexAttribArray(position);
+    gl.vertexAttribPointer(position, 2, gl.FLOAT, false, 0, 0);
+
+    const uResolution = gl.getUniformLocation(program, "uResolution");
+    const uTime = gl.getUniformLocation(program, "uTime");
+    const uPointer = gl.getUniformLocation(program, "uPointer");
+    const uPointerOn = gl.getUniformLocation(program, "uPointerOn");
+
+    gl.uniform3fv(gl.getUniformLocation(program, "uWave"), WAVE);
+    gl.uniform1f(gl.getUniformLocation(program, "uPixel"), PIXEL);
+    gl.uniform1f(gl.getUniformLocation(program, "uSteps"), STEPS);
+
+    /*
+     * O buffer tem o tamanho em pixels de **CSS**, não em pixels do aparelho.
+     * Numa tela retina isso é um quarto dos fragmentos, e o upscale não custa
+     * nitidez nenhuma: `image-rendering: pixelated` no CSS mantém a célula
+     * quadrada, que é o que a trama quer de qualquer forma.
+     */
+    const resize = () => {
+      const width = Math.max(1, Math.round(canvas.clientWidth));
+      const height = Math.max(1, Math.round(canvas.clientHeight));
+      if (canvas.width === width && canvas.height === height) return;
+
+      canvas.width = width;
+      canvas.height = height;
+      gl.viewport(0, 0, width, height);
+      gl.uniform2f(uResolution, width, height);
+    };
+
+    // Guardado em pixels de CSS, com origem no topo; o shader lê com origem
+    // embaixo, como `gl_FragCoord`.
+    const pointer = { x: 0, y: 0, on: 0 };
+
+    const draw = (seconds: number) => {
+      resize();
+      gl.uniform1f(uTime, seconds * SPEED);
+      gl.uniform2f(uPointer, pointer.x, canvas.height - pointer.y);
+      gl.uniform1f(uPointerOn, pointer.on);
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+    };
+
+    const motion = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    let frame: number | null = null;
+    let origin = 0;
+
+    const loop = (now: number) => {
+      if (!origin) origin = now;
+      draw((now - origin) / 1000);
+      frame = requestAnimationFrame(loop);
+    };
+
+    /*
+     * Sem movimento a trama **continua lá**, congelada num quadro. Apagar o
+     * fundo seria trocar um enfeite por um vazio; o que incomoda em
+     * `prefers-reduced-motion` é a onda andando, não o desenho existir.
+     */
+    const sync = () => {
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+        frame = null;
+      }
+
+      if (motion.matches || document.hidden) {
+        pointer.on = 0;
+        draw(0);
+        return;
+      }
+
+      origin = 0;
+      frame = requestAnimationFrame(loop);
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      if (motion.matches) return;
+      pointer.x = event.clientX;
+      pointer.y = event.clientY;
+      pointer.on = 1;
+    };
+
+    const onPointerLeave = () => {
+      pointer.on = 0;
+    };
+
+    // O canvas é `pointer-events: none`, então quem sabe do cursor é a janela.
+    window.addEventListener("pointermove", onPointerMove, { passive: true });
+    document.addEventListener("pointerleave", onPointerLeave);
+    document.addEventListener("visibilitychange", sync);
+    window.addEventListener("resize", sync);
+    motion.addEventListener("change", sync);
+
+    sync();
+
+    return () => {
+      if (frame !== null) cancelAnimationFrame(frame);
+      window.removeEventListener("pointermove", onPointerMove);
+      document.removeEventListener("pointerleave", onPointerLeave);
+      document.removeEventListener("visibilitychange", sync);
+      window.removeEventListener("resize", sync);
+      motion.removeEventListener("change", sync);
+      gl.deleteBuffer(buffer);
+      gl.deleteProgram(program);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="dither" aria-hidden="true" />;
+}

--- a/components/ui/Shell.tsx
+++ b/components/ui/Shell.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { AUTHORS, PROJECT_REPO_URL } from "@/lib/config";
 import { translator, type Locale } from "@/lib/i18n/dictionaries";
 import { getProjectStars } from "@/lib/project";
+import { DitherBackground } from "./DitherBackground";
 import { LocaleToggle } from "./LocaleToggle";
 import { SupportBand } from "./SupportBand";
 
@@ -14,16 +15,30 @@ import { SupportBand } from "./SupportBand";
  */
 export async function Shell({
   locale,
+  landing = false,
   children,
 }: {
   locale: Locale;
+  /**
+   * Chrome da home: a página inteira cabe numa tela, o fundo ganha a trama e a
+   * faixa de apoio encolhe para uma linha.
+   *
+   * É uma propriedade só, e não três, porque as três decisões são a mesma: a
+   * home não rola, então tudo que mora fora do miolo tem um orçamento de altura
+   * — e o fundo, que numa página que rola seria uma distração deslizando, numa
+   * que não rola é a única coisa que se move. Nas páginas de carta nada disso
+   * vale: lá a altura é do conteúdo, e quem tem que respirar é a carta.
+   */
+  landing?: boolean;
   children: React.ReactNode;
 }) {
   const t = translator(locale);
   const stars = await getProjectStars();
 
   return (
-    <div className="shell">
+    <div className="shell" data-landing={landing || undefined}>
+      {landing ? <DitherBackground /> : null}
+
       <header className="shell-header">
         <Link href="/" className="brand">
           <span className="brand-mark" aria-hidden="true" />
@@ -44,7 +59,7 @@ export async function Shell({
 
       <main className="shell-main">{children}</main>
 
-      <SupportBand locale={locale} stars={stars} />
+      <SupportBand locale={locale} stars={stars} compact={landing} />
 
       {/*
         O sponsor saiu daqui e foi para a faixa acima: no rodapé ele era um link

--- a/components/ui/SupportBand.tsx
+++ b/components/ui/SupportBand.tsx
@@ -16,17 +16,25 @@ import { translator, type Locale } from "@/lib/i18n/dictionaries";
 export function SupportBand({
   locale,
   stars,
+  compact = false,
 }: {
   locale: Locale;
   stars: number | null;
+  /**
+   * Uma linha só, sem o parágrafo. É o formato da home, onde a página inteira
+   * cabe numa tela e cada bloco tem um orçamento de altura — e onde a explicação
+   * não faz falta, porque o pedido está a dois cliques de distância do que a
+   * pessoa acabou de ver funcionar.
+   */
+  compact?: boolean;
 }) {
   const t = translator(locale);
 
   return (
-    <aside className="support-band">
+    <aside className="support-band" data-compact={compact || undefined}>
       <div className="support-copy">
         <h2>{t("support.title")}</h2>
-        <p>{t("support.description")}</p>
+        {compact ? null : <p>{t("support.description")}</p>}
       </div>
 
       <div className="support-actions">

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -289,6 +289,30 @@ test.describe("site", () => {
     await expect(samples.first()).toBeVisible();
   });
 
+  /*
+   * A home cabe numa tela, e é a única página do site em que isso vale.
+   *
+   * A regressão aqui é silenciosa por construção: um bloco cresce alguns
+   * pixels, a barra de rolagem volta, e nada quebra — a página continua
+   * inteira, só deixa de ser a composição que ela é. Sem este teste, o sintoma
+   * só aparece para quem abre a home.
+   *
+   * A altura importa mais que a largura: abaixo de 560px de altura a home volta
+   * a rolar de propósito (não há espaço para espremer), então a medida é feita
+   * acima desse corte.
+   */
+  test("a home cabe na tela, sem rolagem", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("/");
+
+    const doc = await page.evaluate(() => ({
+      scroll: document.documentElement.scrollHeight,
+      client: document.documentElement.clientHeight,
+    }));
+
+    expect(doc.scroll).toBe(doc.client);
+  });
+
   test("troca o idioma da interface e mantém a escolha", async ({ page }) => {
     await page.goto("/");
     await page.getByRole("button", { name: "English" }).click();


### PR DESCRIPTION
A home dizia três coisas — o que é, como usar, como é o resultado — espalhadas por uma página que rolava, sem eixo comum: herói alinhado à esquerda, cartas numa grade centrada, faixa de apoio com peso de bloco. Agora as três cabem juntas na tela e dividem o mesmo eixo vertical, com o cabeçalho e a faixa fechando a composição em cima e embaixo pelo mesmo fio de 1px.

## Cabe numa tela

`Shell` ganhou `landing`, e só a home passa. Acima de 560px de altura o shell trava em `100dvh` e o miolo centraliza no que sobra.

O ajuste é **por altura, não por largura**: tipografia e largura das cartas crescem em `vh` com teto em `vw`, então a composição encolhe junto em vez de estourar. Abaixo de 560px de altura a home volta a rolar de propósito — lá não há o que espremer, e "sem scroll" é uma promessa sobre a composição, não sobre a régua.

O `overflow-y: clip` da landing é por eixo, e não pelo atalho `overflow`: o horizontal já é cortado pela regra que #26 acabou de introduzir para o pacote não sair do centro no telefone, e o atalho a apagaria justamente na home.

Medido em 1440×900, 1280×720, 1512×1080 e 390×844 — `scrollHeight === clientHeight` nos quatro.

## Fundo dithered

`components/ui/DitherBackground.tsx`: o `Dither` do React Bits portado à mão em WebGL cru. É a mesma decisão que o `TiltCard` já tinha tomado com o `ReflectiveCard` da mesma biblioteca, pelo mesmo motivo — o original roda sobre `three` + `@react-three/fiber` + `postprocessing`, e ~600 KB de motor 3D para desenhar um quad de tela cheia não passa num projeto de cinco dependências de runtime. **Nenhuma dependência nova.**

Ruído simplex somado em oitavas desenha as ondas, a imagem é quantizada em 4 níveis e uma matriz de Bayer 8×8 espalha o erro dessa quantização. Um pass só em vez dos dois do original: pixelar antes de amostrar dá o mesmo resultado que renderizar grande e reduzir depois. A saída é em **alpha**, não em RGB, então quem pinta o fundo continua sendo `--bg` — se o componente não montar (WebGL indisponível, JS desligado), a home fica exatamente como era.

Sob `prefers-reduced-motion` a trama congela num quadro em vez de sumir: o que incomoda é a onda andando, não o desenho existir. Pausa também com a aba oculta.

## Cartas

- **Juntas, como na mão.** 4% de sobreposição — mais que isso e a vizinha começa a comer os PS, que ficam no canto superior direito da arte. A apontada sobe, vem para a frente e afasta as outras duas. Quem sobe é a carta, não o item: os três rótulos ficam na mesma linha de base, que é o alinhamento que esta página existe para ter.
- **Raio proporcional** (`4.7cqw`). Os 16px fixos foram desenhados para os 340px da página de perfil; na home a mesma carta aparece a 198 ou a 117, e ali 16px é quase 15% da largura — o canto comia a moldura impressa no PNG, que tem o próprio raio. `cqw` porque a medida certa é a largura da própria carta: `%` em `border-radius` mede largura na horizontal e **altura** na vertical, o que numa carta 5:7 devolve um canto elíptico. Os 4.7% reproduzem exatamente os 16px na largura de origem.

## Um bug que veio junto

O dropdown do autocomplete pintava **amarelo**, e desde sempre. `.search-form button` (0,1,1) alcançava as sugestões, que também são `<button>`, e ganhava de `.search-dropdown-item` (0,1,0) na cascata: a lista saía com o fundo e o padding do botão de envio. O `:hover` do item (0,2,0) voltava a vencer, então a linha sob o cursor era a única escura — o que fazia o sintoma parecer intencional. O seletor passa a ser `button[type="submit"]`, que é o que de fato separa os dois: um envia o formulário, os outros escolhem um nome.

## Testes

Um e2e novo trava o requisito, porque a regressão aqui é silenciosa por construção — um bloco cresce alguns pixels, a barra volta, e nada quebra.

Verde: `typecheck`, `lint`, 161 unitários, e o e2e inteiro (22 casos, `@stateful` de fora). O `/ não rola de lado` que veio no #26 agora cobre a landing nova.

> Nota: com 4 workers neste disco o `next dev` frio derruba alguns casos por timeout de compilação, sem relação com o diff; serial passa tudo.

## O que ficou de fora

No celular a faixa de apoio empilha em três linhas. Cabe na tela e está legível, mas fica um pouco solta — dá para apertar, se valer a pena.